### PR TITLE
Support changes for outputting mmCIF files using molmodel objects

### DIFF
--- a/include/molmodel/internal/Compound.h
+++ b/include/molmodel/internal/Compound.h
@@ -44,6 +44,14 @@
 
 #include <iosfwd> // declare ostream without all the definitions
 
+#ifdef MMDB2_LIB_USAGE
+  #include <mmdb2/mmdb_manager.h>
+#endif
+
+#ifdef CPP4_MAPS_USAGE
+  #include <mmdb2/mmdb_manager.h>
+#endif
+
 namespace SimTK {
 class CompoundSystem;
 
@@ -833,6 +841,28 @@ public:
         const Transform& transform = Transform() ///< optional change to location and orientation of molecule
         ) const;
 
+     /** \brief Write the entity_poly_seq loop into the MMDB2 Data object.
+      *
+      * This function writes the poly_seq loop into the supplied MMDB2 mmCIF file object. This is required for a proper
+      * mmCIF file to be created.
+      */
+     void writeEntityPolySeqLoop(
+         const State& state, ///< simbody state representing the current configuration of the molecule
+         mmdb::io::File *cifFile,  ///< MMDB2 File pointer - to this file object will the loop be written into.
+         int compoundNumber ///< Compound number.
+         ) const;
+
+     /** \brief Create the MMDB2 object structure for mmCIF writing..
+      *
+      * Starting with the first atom's serial number as one(1), this function will fill in the MMDB2 objects structure with the structural
+      * data so that these can be written into a mmCIF file.
+      */
+     void buildCif(
+         const State& state, ///< simbody state representing the current configuration of the molecule
+         mmdb::Model* mmdb2Model,  ///< MMDB2 library model object pointer to which the MMDB2 object structure will be build into.
+         const Transform& transform = Transform() ///< optional change to location and orientation of molecule
+         ) const;
+    
     /**
      * \brief Write the dynamic Compound configuration in Protein Data Bank (PDB) format.
      *

--- a/include/molmodel/internal/Pdb.h
+++ b/include/molmodel/internal/Pdb.h
@@ -206,7 +206,7 @@ protected:
     /// Try to be smart about guessing correct atom name for names that are not 4 characters long
     static std::vector<SimTK::String> generatePossibleAtomNames(SimTK::String name);
 
-private:
+public:
     Element element;
 
     // avoid dll export warnings for these private types
@@ -216,7 +216,6 @@ private:
 #endif
 
     SimTK::String atomName;
-public:
     typedef std::vector<PdbAtomLocation> Locations;
     Locations locations;
     std::map<char, int> locationIndicesById;

--- a/src/CompoundRep.h
+++ b/src/CompoundRep.h
@@ -1758,6 +1758,26 @@ public:
     //    const Transform& transform
     //    ) const;
 
+  /**
+   * \brief Write the entity_poly_seq loop into the MMDB2 Data object.
+   */
+  void writeEntityPolySeqLoop(
+      const State& state, ///< simbody state representing the current configuration of the molecule
+      mmdb::io::File *cifFile,  ///< MMDB2 File pointer - to this file object will the loop be written into.
+      int compoundNumber ///< Compound number.
+      ) const;
+
+  /**
+   * \brief Create the MMDB2 object structure for mmCIF writing..
+   *
+   * Starting with the first atom's serial number as one(1).
+   */
+  void buildCif(
+      const State& state, ///< simbody state representing the current configuration of the molecule
+      mmdb::Model* mmdb2Model,  ///< MMDB2 library model object pointer to which the MMDB2 object structure will be build into.
+      const Transform& transform ///< optional change to location and orientation of molecule
+      ) const;
+    
     std::ostream& writePdb(
         const State& state, 
         std::ostream& os, 


### PR DESCRIPTION
This commit contains the changes required to allow writing out mmCIF files using the molmodel objects from MMB. These changes can be summarised as follows:

Compound.h

* Added the MMDB2 include conditioned upon compilation with the MMDB2_LIB_USAGE or CPP4_MAPS_USAGE pre-processor macros. This makes the assumption that the MMDB2 library is installed into a system location include in the standard path.
* Added the declarations of writeEntityPolySeqLoop() and buildCif() to the Compound class.

Compound.cpp

* Added the include for Pdb.h and <regex>, as the new code uses functions from both headers.
* Added the writeEntityPolySeqLoop() function to the Compound class. This function simply calls the writeEntityPolySeqLoop() function of the CompoundRep class.
* Added the buildCif() function to the Compound class. This function simply calls the buildCif() function of the CompoundRep class.
* Added the writeEntityPolySeqLoop() function to the CompoundRep class. This function does the writing of the poly_seq loop to the MMDB2 mmCIF file object.
* Added the buildCif() function to the CompoundRep class. This function iterates through all molmodel atom objects (using the chain and residue objects) and copies all the required information to similar structure of MMDB2 objects.

CompoundRep.h

* Added the writeEntityPolySeqLoop() function declaration to the CompoundRep class. This function will write the poly_seq loop to MMDB2 mmCIF file object so that the resulting mmCIF file would have the proper required contents.
* Added the buildCif() function declaration to the CompoundRep class. This function copies the molmodel object structure information into a similar MMDB2 object structure so that it could be written in to a mmCIF file.

Pdb.h

* Changed the element and atomName variables from privat to public in the PdbAtom class. This is required for accessing these from the new code.