### PR TITLE
Correcting the previous commit - forgot to add the protection pragma.

### DIFF
--- a/include/molmodel/internal/Compound.h
+++ b/include/molmodel/internal/Compound.h
@@ -846,6 +846,8 @@ public:
       * This function writes the poly_seq loop into the supplied MMDB2 mmCIF file object. This is required for a proper
       * mmCIF file to be created.
       */
+    
+#ifdef MMDB2_LIB_USAGE
      void writeEntityPolySeqLoop(
          const State& state, ///< simbody state representing the current configuration of the molecule
          mmdb::io::File *cifFile,  ///< MMDB2 File pointer - to this file object will the loop be written into.
@@ -862,6 +864,7 @@ public:
          mmdb::Model* mmdb2Model,  ///< MMDB2 library model object pointer to which the MMDB2 object structure will be build into.
          const Transform& transform = Transform() ///< optional change to location and orientation of molecule
          ) const;
+#endif
     
     /**
      * \brief Write the dynamic Compound configuration in Protein Data Bank (PDB) format.

--- a/src/Compound.cpp
+++ b/src/Compound.cpp
@@ -1004,6 +1004,7 @@ std::ostream& CompoundRep::writeDefaultPdb(std::ostream& os, int& nextSerialNumb
     return os;
 }
 
+#ifdef MMDB2_LIB_USAGE
 void CompoundRep::writeEntityPolySeqLoop( const State& state, mmdb::io::File *cifFile, int compoundNumber ) const
 {
     //================================================ Prepare the basic sequence loop ( _entity_poly_seq )
@@ -1143,6 +1144,7 @@ void CompoundRep::buildCif( const State& state, mmdb::Model* mmdb2Model, const T
     //================================================ Done
     return;
 }
+#endif
 
 ostream& CompoundRep::writePdb(const State& state, ostream& os, const Transform& transform) const  
 {
@@ -2091,6 +2093,7 @@ void Compound::writeDefaultPdb(const char* outFileName, const Transform& transfo
     os.close();
 }
 
+#ifdef MMDB2_LIB_USAGE
 void Compound::writeEntityPolySeqLoop( const State& state, mmdb::io::File *cifFile, int compoundNumber ) const
 {
     getImpl().writeEntityPolySeqLoop ( state, cifFile, compoundNumber );
@@ -2102,6 +2105,7 @@ void Compound::buildCif( const State& state, mmdb::Model* mmdb2Model, const Tran
     getImpl().buildCif ( state, mmdb2Model, transform );
     return ;
 }
+#endif
 
 ostream& Compound::writePdb(const SimTK::State& state, ostream& os, const Transform& transform) const  
 {

--- a/src/CompoundRep.h
+++ b/src/CompoundRep.h
@@ -1758,6 +1758,7 @@ public:
     //    const Transform& transform
     //    ) const;
 
+#ifdef MMDB2_LIB_USAGE
   /**
    * \brief Write the entity_poly_seq loop into the MMDB2 Data object.
    */
@@ -1777,6 +1778,7 @@ public:
       mmdb::Model* mmdb2Model,  ///< MMDB2 library model object pointer to which the MMDB2 object structure will be build into.
       const Transform& transform ///< optional change to location and orientation of molecule
       ) const;
+#endif
     
     std::ostream& writePdb(
         const State& state, 


### PR DESCRIPTION
Forgot to add the protection pragma MMDB2_LIB_USAGE to the newly added functions. This caused compilation errors as the new changes requiring the MMDB2 library were visible even when the CMake was run without the -DADD_MMDB2_LIBRARY=TRUE option, this causing errors. Hopefully this solves the issue.