### PR TITLE
Switching to gemmi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1 +1,1743 @@
-#---------------------------------------------------# Molmodel ## Creates SimTK library, base name=SimTKmolmodel.# Default libraries are shared & optimized. Variants# are created for static (_static) and debug (_d) and# provision is made for an optional "namespace" (ns)# and version number (vn).## Windows:#   [ns_]SimTKmolmodel[_vn][_d].dll#   [ns_]SimTKmolmodel[_vn][_d].lib#   [ns_]SimTKmolmodel[_vn]_static[_d].lib# Unix:#   lib[ns_]SimTKmolmodel[_vn][_d].so#   lib[ns_]SimTKmolmodel[_vn]_static[_d].a## All libraries are installed in #   %ProgramFiles%\SimTK\lib    (Windows)#   /usr/local/SimTK/lib[64]    (Linux, Mac)## Also creates an OpenMM plugin DLL that is used at# runtime to determine whether OpenMM is available.# That DLL is named#   OpenMMPlugin[_d].dll#   libOpenMMPlugin[_d].so#   libOpenMMPlugin[_d].dylib# And there is no static version.#----------------------------------------------------cmake_minimum_required(VERSION 2.8)project(Molmodel)set(MOLMODEL_MAJOR_VERSION 3)set(MOLMODEL_MINOR_VERSION 0)set(MOLMODEL_PATCH_VERSION 0)set(MOLMODEL_COPYRIGHT_YEARS "2006-12")# underbar separated list of dotted authors, no spaces or commasset(MOLMODEL_AUTHORS "Christopher.Bruns_Michael.Sherman")# Report the version number to the CMake UI. Don't include the # build version if it is zero.set(PATCH_VERSION_STRING)IF(MOLMODEL_PATCH_VERSION)    SET(PATCH_VERSION_STRING ".${MOLMODEL_PATCH_VERSION}")ENDIF()set(MOLMODEL_VERSION     "${MOLMODEL_MAJOR_VERSION}.${MOLMODEL_MINOR_VERSION}${PATCH_VERSION_STRING}"    CACHE STRING     "This is the version that will be built (can't be changed here)."     FORCE)#set(MOLMODEL_SONAME_VERSION#    "${MOLMODEL_MAJOR_VERSION}.${MOLMODEL_MINOR_VERSION}"#    CACHE STRING#    "Soname version; appended to names of shared libs#    (can't be changed in GUI)."#    FORCE)#set(SONAME#    "${MOLMODEL_MAJOR_VERSION}.${MOLMODEL_MINOR_VERSION}"#    CACHE STRING#    "Soname version; appended to names of shared libs#    (can't be changed in GUI)."#    FORCE)# This is the suffix if we're building and depending on versioned libraries.set(VN "_${MOLMODEL_VERSION}")set(BUILD_BINARY_DIR ${CMAKE_BINARY_DIR}    CACHE PATH     "The Molmodel build (not the install) puts all the libraries and executables together here (with /Release, etc. appended on some platforms).")# Make everything go in the same binary directory. (These are CMake-defined# variables.)set(EXECUTABLE_OUTPUT_PATH ${BUILD_BINARY_DIR})set(LIBRARY_OUTPUT_PATH ${BUILD_BINARY_DIR})# Static libraries, tests, and examples won't be built unless this # is set.SET(BUILD_STATIC_LIBRARIES FALSE CACHE BOOL"Build '_static' versions of libraries in addition to dynamic libraries?")# Use this to generate a private set of libraries whose names# won't conflict with installed versions.set(BUILD_USING_NAMESPACE "" CACHE STRING	"All library names will be prefixed with 'xxx_' if this is set to xxx.")set(BUILD_UNVERSIONED_LIBRARIES TRUE CACHE BOOL "Build library names, and assume dependency names, with no version numbers?")set(BUILD_VERSIONED_LIBRARIES FALSE CACHE BOOL "Build library names, and assume dependency names, with version numbers?")set(NS)if(BUILD_USING_NAMESPACE)    set(NS "${BUILD_USING_NAMESPACE}_")endif()set(MOLMODEL_LIBRARY_NAME ${NS}SimTKmolmodel CACHE STRING"Base name of the library being built; can't be changed here; see BUILD_USING_NAMESPACE variable."FORCE)# Permit use of custom FindOpenMM and FindSimbody modulesset(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")set(CMAKE_VERBOSE_MAKEFILE OFF CACHE BOOL "Control volume of build output" )set(OpenMM_ON OFF)find_package(OpenMM)if(OpenMM_FOUND)    set(OpenMM_ON ON)endif()set(MOLMODEL_USE_OpenMM ${OpenMM_ON} CACHE BOOL    "Control whether Molmodel builds the OpenMM Plugin (requires that OpenMM is installed on the build machine)." )# Caution: this variable is automatically created by the CMake# ENABLE_TESTING() command, but we'll take it over here for# our own purposes too.set(BUILD_TESTING ON CACHE BOOL	"Control building of Molmodel test programs." )set(BUILD_EXAMPLES ON CACHE BOOL	"Control building of Molmodel example programs." )# Turning this off reduces the build time (and space) substantially,# but you may miss the occasional odd bug. Also currently on Windows it# is easier to debug the static tests than the DLL-liked ones.SET( BUILD_TESTING_STATIC ON CACHE BOOL    "If building static libraries, build static test and example programs too?" )SET( BUILD_TESTING_SHARED ON CACHE BOOL    "If building test or example programs, include dynamically-linked ones?" )## Create a platform name useful for some platform-specific stuff.IF(WIN32)    SET(NATIVE_COPY_CMD copy)ELSEIF(APPLE)    SET(NATIVE_COPY_CMD cp)ELSE()    SET(NATIVE_COPY_CMD cp)ENDIF()# In addition to the platform name we need to know the Application Binary# Interface (ABI) we're building for. Currently that is either x86, meaning# 32 bit Intel instruction set, or x64 for 64 bit Intel instruction set.IF(${CMAKE_SIZEOF_VOID_P} EQUAL 8)    SET(PLATFORM_ABI x64)ELSE()    SET(PLATFORM_ABI x86)ENDIF()SET(BUILD_PLATFORM "${CMAKE_HOST_SYSTEM_NAME}:${PLATFORM_ABI}" CACHE STRING    "This is the platform and ABI we're building for. Not changeable here; use a different CMake generator instead."    FORCE)# Find Simbody using the local FindSimbody.cmake if present.find_package(Simbody REQUIRED)include_directories(${Simbody_INCLUDE_DIR})link_directories(${Simbody_LIB_DIR})# If CMAKE_INSTALL_PREFIX is /usr/local, then the LIBDIR should necessarily be# lib/. Sometimes (on Linux), LIBDIR is something like x86_64-linux-gnu. The# linker will search /usr/lib/x86_64-linux-gnu (this path is in# /etc/ld.so.conf.d), but it will NOT search /usr/local/lib/x86-64-linux-gnu.# HOWEVER, it WILL search /usr/local/lib. So that Linux users needn't modify# their LD_LIBRARY_PATH if installing to /usr/local, we force the LIBDIR to be# lib/.# Note: CMake 3.0 fixes this issue. When we move to CMake 3.0, we can# remove this if-statement. See issue #151.IF("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local" OR        "${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local/")    # Overwrite both of these variables; we use both of them.    SET(CMAKE_INSTALL_LIBDIR "lib")    SET(CMAKE_INSTALL_FULL_LIBDIR        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")ENDIF()IF(NOT MSVC AND NOT XCODE AND NOT CMAKE_BUILD_TYPE)    SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING         "Debug, RelWithDebInfo (recommended), or Release build"         FORCE)ENDIF()## Choose the maximum level of x86 instruction set that the compiler is ## allowed to use. ## Was using sse2 but changed to let the compilers choose. Most will## probably use sse2 or later by default.## On 64 bit MSVC 2013, the default is sse2 and the argument## isn't recognized so don't specify it.if (CMAKE_CL_64)    set(default_build_inst_set)else()    set(default_build_inst_set)endif()## This can be set to a different value by the person running CMake.SET(BUILD_INST_SET ""    CACHE STRING     "CPU instruction level compiler is permitted to use (default: let compiler decide).")MARK_AS_ADVANCED( BUILD_INST_SET )if (BUILD_INST_SET)    set(inst_set_to_use ${BUILD_INST_SET})else()    set(inst_set_to_use ${default_build_inst_set})endif()## When building in any of the Release modes, tell gcc/clang to use ## not-quite most agressive optimization.  Here we ## are specifying *all* of the Release flags, overriding CMake's defaults.## Watch out for optimizer bugs in particular gcc versions!IF(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR   ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")    # If using either of these compilers, provide the option of     # compiling using the c++11 standard.    OPTION(SIMBODY_STANDARD_11        "Compile using the C++11 standard, if using GCC or Clang." ON)        IF(${SIMBODY_STANDARD_11})        # Using C++11 on OSX requires using libc++ instead of libstd++.        # libc++ is an implementation of the C++ standard library for OSX.        IF(APPLE)            IF(XCODE)                SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")                SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")            ELSE()                SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")                SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")            ENDIF()        ELSE() # not APPLE            SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")        ENDIF()    ENDIF()    if (inst_set_to_use)        string(TOLOWER ${inst_set_to_use} GCC_INST_SET)        set(GCC_INST_SET "-m${GCC_INST_SET}")    else()        set(GCC_INST_SET)    endif()    # Get the gcc or clang version number in major.minor.build format    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion                    OUTPUT_VARIABLE GCC_VERSION)    # Unrolling fixed-count loops was a useful optimization for Simmatrix    # in earlier gcc versions.    # Doesn't have a big effect for current compiler crop and may be     # pushing our luck with optimizer bugs. So let the compilers decide    # how to handle loops instead.    ##SET(GCC_OPT_ENABLE "-funroll-loops")    # If you know of optimization bugs that affect Simbody in particular    # gcc versions, this is the place to turn off those optimizations.    SET(GCC_OPT_DISABLE)    # We know Gcc 4.4.3 on Ubuntu 10 is buggy.    IF(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")      if (GCC_VERSION VERSION_EQUAL 4.4)        SET(GCC_OPT_DISABLE         "-fno-strict-aliasing -fno-tree-vrp -fno-guess-branch-probability")      endif()    ENDIF()    # C++    SET(BUILD_CXX_FLAGS_DEBUG          "-g ${GCC_INST_SET}")    SET(BUILD_CXX_FLAGS_RELEASE              "-DNDEBUG -O2 ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")    SET(BUILD_CXX_FLAGS_RELWITHDEBINFO     "-DNDEBUG -O2 -g ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")    SET(BUILD_CXX_FLAGS_MINSIZEREL     "-DNDEBUG -Os ${GCC_INST_SET}")    # C    SET(BUILD_C_FLAGS_DEBUG            "-g ${GCC_INST_SET}")    SET(BUILD_C_FLAGS_RELEASE                "-DNDEBUG -O2 ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")    SET(BUILD_C_FLAGS_RELWITHDEBINFO       "-DNDEBUG -O2 -g ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")    SET(BUILD_C_FLAGS_MINSIZEREL       "-DNDEBUG -Os ${GCC_INST_SET}")    # C++    SET(CMAKE_CXX_FLAGS_DEBUG ${BUILD_CXX_FLAGS_DEBUG}        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    SET(CMAKE_CXX_FLAGS_RELEASE ${BUILD_CXX_FLAGS_RELEASE}        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO ${BUILD_CXX_FLAGS_RELWITHDEBINFO}        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    SET(CMAKE_CXX_FLAGS_MINSIZEREL ${BUILD_CXX_FLAGS_MINSIZEREL}        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    # C    SET(CMAKE_C_FLAGS_DEBUG ${BUILD_C_FLAGS_DEBUG}        CACHE STRING "Can't change here -- see BUILD_C..." FORCE)    SET(CMAKE_C_FLAGS_RELEASE ${BUILD_C_FLAGS_RELEASE}                 CACHE STRING "Can't change here -- see BUILD_C..." FORCE)    SET(CMAKE_C_FLAGS_RELWITHDEBINFO ${BUILD_C_FLAGS_RELWITHDEBINFO}        CACHE STRING "Can't change here -- see BUILD_C..." FORCE)    SET(CMAKE_C_FLAGS_MINSIZEREL ${BUILD_C_FLAGS_MINSIZEREL}        CACHE STRING "Can't change here -- see BUILD_C..." FORCE)ENDIF()## When building in any of the Release modes, tell VC++ cl compiler to use ## intrinsics (i.e. sqrt instruction rather than sqrt subroutine) with ## flag /Oi.## Caution: can't use CMAKE_CXX_COMPILER_ID MATCHES MSVC here because## "MSVC" is a predefined CMAKE variable and will get expanded to 1 or 0IF(MSVC)    if (inst_set_to_use)        string(TOUPPER ${inst_set_to_use} CL_INST_SET)        set(CL_INST_SET "/arch:${CL_INST_SET}")    else()        set(CL_INST_SET)    endif()    set(BUILD_LIMIT_PARALLEL_COMPILES "" CACHE STRING        "Set a maximum number of simultaneous compilations.")    mark_as_advanced(BUILD_LIMIT_PARALLEL_COMPILES)    set(mxcpu ${BUILD_LIMIT_PARALLEL_COMPILES}) # abbreviation    ## C++    SET(BUILD_CXX_FLAGS_DEBUG            "/D _DEBUG /MDd /Od /Ob0 /RTC1 /Zi /GS- ${CL_INST_SET}")    SET(BUILD_CXX_FLAGS_RELEASE            "/D NDEBUG /MD  /O2 /Ob2 /Oi /GS- ${CL_INST_SET}")    SET(BUILD_CXX_FLAGS_RELWITHDEBINFO     "/D NDEBUG /MD  /O2 /Ob2 /Oi /Zi /GS- ${CL_INST_SET}")    SET(BUILD_CXX_FLAGS_MINSIZEREL     "/D NDEBUG /MD  /O1 /Ob1 /Oi /GS- ${CL_INST_SET}")    ## C    SET(BUILD_C_FLAGS_DEBUG            "/D _DEBUG /MDd /Od /Ob0 /RTC1 /Zi /GS- ${CL_INST_SET}")    SET(BUILD_C_FLAGS_RELEASE            "/D NDEBUG /MD  /O2 /Ob2 /Oi /GS- ${CL_INST_SET}")    SET(BUILD_C_FLAGS_RELWITHDEBINFO     "/D NDEBUG /MD  /O2 /Ob2 /Oi /Zi /GS- ${CL_INST_SET}")    SET(BUILD_C_FLAGS_MINSIZEREL     "/D NDEBUG /MD  /O1 /Ob1 /Oi /GS- ${CL_INST_SET}")    ## C++    SET(CMAKE_CXX_FLAGS_DEBUG "/MP${mxcpu} ${BUILD_CXX_FLAGS_DEBUG}"        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    SET(CMAKE_CXX_FLAGS_RELEASE "/MP${mxcpu} ${BUILD_CXX_FLAGS_RELEASE}"        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/MP${mxcpu} ${BUILD_CXX_FLAGS_RELWITHDEBINFO}"        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    SET(CMAKE_CXX_FLAGS_MINSIZEREL "/MP${mxcpu} ${BUILD_CXX_FLAGS_MINSIZEREL}"        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    ## C    SET(CMAKE_C_FLAGS_DEBUG "/MP${mxcpu} ${BUILD_C_FLAGS_DEBUG}"        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)    SET(CMAKE_C_FLAGS_RELEASE "/MP${mxcpu} ${BUILD_C_FLAGS_RELEASE}"        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)    SET(CMAKE_C_FLAGS_RELWITHDEBINFO "/MP${mxcpu} ${BUILD_C_FLAGS_RELWITHDEBINFO}"        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)    SET(CMAKE_C_FLAGS_MINSIZEREL "/MP${mxcpu} ${BUILD_C_FLAGS_MINSIZEREL}"        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)ENDIF()# The source is organized into subdirectories, but we handle them all from# this CMakeLists file rather than letting CMake visit them as SUBDIRS.set(MOLMODEL_SOURCE_SUBDIRS .)# Collect up information about the version of the molmodel library we're building# and make it available to the code so it can be built into the binaries.# Get the subversion revision number if we can# It's possible that WIN32 installs use svnversion through cygwin# so we'll try for both svnversion.exe and svnversion. Note that# this will result in warnings if all you have is Tortoise without# Cygwin, and your "about" string will say "unknown" rather than# providing the SVN version of the source.# If there is an actual reason for the SVNVERSION vs. SVNVERSION_EXE# nonsense that was here before, come talk to me.  --Chris Bruns# 1) CMake already understands that Windows executables have ".exe" at the end.# 2) Providing a PATHS argument to find_program is *NOT* hard coding a single path.# Please read the CMake documentation for more details.find_program(SVNVERSION_EXECUTABLE svnversion PATHS "C:/cygwin/bin")if(SVNVERSION_EXECUTABLE)    exec_program(${SVNVERSION_EXECUTABLE}              # Works better on Windows to set working directory rather than              # passing argument to svnversion              ${CMAKE_SOURCE_DIR} # cwd for run              OUTPUT_VARIABLE OUT)    set(MOLMODEL_SVN_REVISION "${OUT}" CACHE STRING "Molmodel svn revision number" FORCE)else(SVNVERSION_EXECUTABLE)    message(STATUS          "Could not find 'svnversion' executable; 'about' will be wrong. (Cygwin provides one on Windows.)"        )    set(MOLMODEL_SVN_REVISION "unknown" CACHE STRING "Molmodel svn revision number")endif(SVNVERSION_EXECUTABLE)mark_as_advanced(MOLMODEL_SVN_REVISION)# Remove colon from build version, for easier placement in directory namesSTRING(REPLACE ":" "_" MOLMODEL_SVN_REVISION ${MOLMODEL_SVN_REVISION})ADD_DEFINITIONS(-DSimTK_MOLMODEL_LIBRARY_NAME=${MOLMODEL_LIBRARY_NAME}                -DSimTK_MOLMODEL_MAJOR_VERSION=${MOLMODEL_MAJOR_VERSION}                -DSimTK_MOLMODEL_MINOR_VERSION=${MOLMODEL_MINOR_VERSION}		-DSimTK_MOLMODEL_PATCH_VERSION=${MOLMODEL_PATCH_VERSION})# CMake quotes automatically when building Visual Studio projects but we need# to add them ourselves for Linux or Cygwin. Two cases to avoid duplicate quotes# in Visual Studio which end up in the binary.IF (${CMAKE_GENERATOR} MATCHES "Visual Studio")   SET(NEED_QUOTES FALSE)ELSE (${CMAKE_GENERATOR} MATCHES "Visual Studio")   SET(NEED_QUOTES TRUE)ENDIF (${CMAKE_GENERATOR} MATCHES "Visual Studio")##TODO: doesn't work without quotes in nightly buildset(NEED_QUOTES TRUE)IF(NEED_QUOTES)   ADD_DEFINITIONS(-DSimTK_MOLMODEL_SVN_REVISION="${MOLMODEL_SVN_REVISION}"                   -DSimTK_MOLMODEL_COPYRIGHT_YEARS="${MOLMODEL_COPYRIGHT_YEARS}"                   -DSimTK_MOLMODEL_AUTHORS="${MOLMODEL_AUTHORS}")ELSE(NEED_QUOTES)   ADD_DEFINITIONS(-DSimTK_MOLMODEL_SVN_REVISION=${MOLMODEL_SVN_REVISION}                   -DSimTK_MOLMODEL_COPYRIGHT_YEARS=${MOLMODEL_COPYRIGHT_YEARS}                   -DSimTK_MOLMODEL_AUTHORS=${MOLMODEL_AUTHORS})ENDIF(NEED_QUOTES)# -DSimTK_MOLMODEL_TYPE has to be defined in the target subdirectories.# -Dmolmodel_EXPORTS defined automatically when Windows DLL build is being done.set(SHARED_TARGET ${MOLMODEL_LIBRARY_NAME})set(STATIC_TARGET ${MOLMODEL_LIBRARY_NAME}_static)set(SHARED_TARGET_VN ${MOLMODEL_LIBRARY_NAME}${VN})set(STATIC_TARGET_VN ${MOLMODEL_LIBRARY_NAME}${VN}_static)# Ensure that debug libraries have "_d" appended to their names.# CMake gets this right on Windows automatically with this definition.IF (${CMAKE_GENERATOR} MATCHES "Visual Studio")    SET(CMAKE_DEBUG_POSTFIX "_d" CACHE INTERNAL "" FORCE)ENDIF (${CMAKE_GENERATOR} MATCHES "Visual Studio")# But on Unix or Cygwin we have to add the suffix manuallyIF (UNIX AND CMAKE_BUILD_TYPE MATCHES Debug)    SET(SHARED_TARGET ${SHARED_TARGET}_d)    SET(STATIC_TARGET ${STATIC_TARGET}_d)    SET(SHARED_TARGET_VN ${SHARED_TARGET_VN}_d)    SET(STATIC_TARGET_VN ${STATIC_TARGET_VN}_d)ENDIF (UNIX AND CMAKE_BUILD_TYPE MATCHES Debug)## Test against the unversioned libraries if they are being built;## otherwise against the versioned libraries.IF(BUILD_UNVERSIONED_LIBRARIES)	SET(TEST_SHARED_TARGET ${SHARED_TARGET})	SET(TEST_STATIC_TARGET ${STATIC_TARGET})ELSE(BUILD_UNVERSIONED_LIBRARIES)	SET(TEST_SHARED_TARGET ${SHARED_TARGET_VN})	SET(TEST_STATIC_TARGET ${STATIC_TARGET_VN})ENDIF(BUILD_UNVERSIONED_LIBRARIES)IF(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")    SET(ADDITIONAL_LINK_LIBRARIES)ELSE(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")    ## Assume Microsoft Visual Studio	## ws2_32 is for socket calls in VMD connection    SET(ADDITIONAL_LINK_LIBRARIES ws2_32)ENDIF(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")SET ( USE_GEMMI  TRUE  CACHE BOOL "Should the Gemmi library be linked to the build?" )SET ( GEMMI_PATH ""    CACHE PATH "Where is the Gemmi library installed?" )IF ( USE_GEMMI )	ADD_DEFINITIONS     ( -DGEMMI_USAGE )	INCLUDE_DIRECTORIES ( ${GEMMI_PATH} )	SET ( ADDITIONAL_LINK_LIBRARIES ${ADDITIONAL_LINK_LIBRARIES} "-lz" )ENDIF ( USE_GEMMI )# These are all the places to search for header files which are# to be part of the API.set(API_INCLUDE_DIRS) # start emptyFOREACH(subdir ${MOLMODEL_SOURCE_SUBDIRS})    # append    SET(API_INCLUDE_DIRS ${API_INCLUDE_DIRS}                         ${subdir}/include                          ${subdir}/include/molmodel                          ${subdir}/include/molmodel/internal)ENDFOREACH(subdir)# We'll need both *relative* path names, starting with their API_INCLUDE_DIRS,# and absolute pathnames.set(API_REL_INCLUDE_FILES)   # start these out emptyset(API_ABS_INCLUDE_FILES)FOREACH(dir ${API_INCLUDE_DIRS})    FILE(GLOB fullpaths ${dir}/*.h)	# returns full pathnames    SET(API_ABS_INCLUDE_FILES ${API_ABS_INCLUDE_FILES} ${fullpaths})    FOREACH(pathname ${fullpaths})        GET_FILENAME_COMPONENT(filename ${pathname} NAME)        SET(API_REL_INCLUDE_FILES ${API_REL_INCLUDE_FILES} ${dir}/${filename})    ENDFOREACH(pathname)ENDFOREACH(dir)# collect up source filesset(SOURCE_FILES) # emptyset(SOURCE_INCLUDE_FILES)FOREACH(subdir ${MOLMODEL_SOURCE_SUBDIRS})    FILE(GLOB src_files  ${subdir}/src/*.cpp ${subdir}/src/*.c                         ${subdir}/src/*/*.cpp ${subdir}/src/*/*.c)    FILE(GLOB incl_files ${subdir}/src/*.h ${subdir}/src/*/*.h )    SET(SOURCE_FILES         ${SOURCE_FILES}         ${src_files})   #append    SET(SOURCE_INCLUDE_FILES ${SOURCE_INCLUDE_FILES} ${incl_files})    ## Make sure we find these locally before looking in    ## SimTK/include if Molmodel was previously installed there.    INCLUDE_DIRECTORIES(BEFORE ${PROJECT_SOURCE_DIR}/${subdir}/include)ENDFOREACH(subdir)INCLUDE_DIRECTORIES(BEFORE ${PROJECT_SOURCE_DIR}/src)## Allow automated build and dashboard.#INCLUDE (Dart)IF (BUILD_TESTING)    #IF (UNIX AND NOT CYGWIN AND NOT APPLE)    #  IF (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE MATCHES Debug)    #    ADD_DEFINITIONS(-fprofile-arcs -ftest-coverage)    #    LINK_LIBRARIES(gcov)    #  ENDIF (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE MATCHES Debug)    #ENDIF (UNIX AND NOT CYGWIN AND NOT APPLE)    #    # Testing    #    ENABLE_TESTING()ENDIF (BUILD_TESTING)INCLUDE(ApiDoxygen.cmake)# libraries are installed from their subdirectories; headers here# install headersFILE(GLOB CORE_HEADERS     include/*.h                  */include/*.h)FILE(GLOB TOP_HEADERS      include/molmodel/*.h          */include/molmodel/*.h)FILE(GLOB INTERNAL_HEADERS include/molmodel/internal/*.h */include/molmodel/internal/*.h)INSTALL_FILES(/include/                 FILES ${CORE_HEADERS})INSTALL_FILES(/include/molmodel/         FILES ${TOP_HEADERS})INSTALL_FILES(/include/molmodel/internal FILES ${INTERNAL_HEADERS})# Install documents.FILE(GLOB TOPLEVEL_DOCS doc/*.pdf doc/*.txt)INSTALL(FILES ${TOPLEVEL_DOCS} DESTINATION doc)# These are at the end because we want them processed after# all the various variables have been set above.IF(BUILD_STATIC_LIBRARIES)        ADD_SUBDIRECTORY( staticTarget )ENDIF()ADD_SUBDIRECTORY( sharedTarget )IF (MOLMODEL_USE_OpenMM)    ADD_SUBDIRECTORY( OpenMMPlugin )ENDIF (MOLMODEL_USE_OpenMM)IF( BUILD_EXAMPLES )  ADD_SUBDIRECTORY( examples )ENDIF()IF( BUILD_TESTING )  ADD_SUBDIRECTORY( tests )ENDIF()
+#---------------------------------------------------
+
+
+# Molmodel 
+
+
+#
+
+
+# Creates SimTK library, base name=SimTKmolmodel.
+
+
+# Default libraries are shared & optimized. Variants
+
+
+# are created for static (_static) and debug (_d) and
+
+
+# provision is made for an optional "namespace" (ns)
+
+
+# and version number (vn).
+
+
+#
+
+
+# Windows:
+
+
+#   [ns_]SimTKmolmodel[_vn][_d].dll
+
+
+#   [ns_]SimTKmolmodel[_vn][_d].lib
+
+
+#   [ns_]SimTKmolmodel[_vn]_static[_d].lib
+
+
+# Unix:
+
+
+#   lib[ns_]SimTKmolmodel[_vn][_d].so
+
+
+#   lib[ns_]SimTKmolmodel[_vn]_static[_d].a
+
+
+#
+
+
+# All libraries are installed in 
+
+
+#   %ProgramFiles%\SimTK\lib    (Windows)
+
+
+#   /usr/local/SimTK/lib[64]    (Linux, Mac)
+
+
+#
+
+
+# Also creates an OpenMM plugin DLL that is used at
+
+
+# runtime to determine whether OpenMM is available.
+
+
+# That DLL is named
+
+
+#   OpenMMPlugin[_d].dll
+
+
+#   libOpenMMPlugin[_d].so
+
+
+#   libOpenMMPlugin[_d].dylib
+
+
+# And there is no static version.
+
+
+#----------------------------------------------------
+
+
+
+
+
+cmake_minimum_required(VERSION 2.8)
+
+
+
+
+
+project(Molmodel)
+
+
+
+
+
+set(MOLMODEL_MAJOR_VERSION 3)
+
+
+set(MOLMODEL_MINOR_VERSION 0)
+
+
+set(MOLMODEL_PATCH_VERSION 0)
+
+
+
+
+
+set(MOLMODEL_COPYRIGHT_YEARS "2006-12")
+
+
+
+
+
+# underbar separated list of dotted authors, no spaces or commas
+
+
+set(MOLMODEL_AUTHORS "Christopher.Bruns_Michael.Sherman")
+
+
+
+
+
+# Report the version number to the CMake UI. Don't include the 
+
+
+# build version if it is zero.
+
+
+set(PATCH_VERSION_STRING)
+
+
+IF(MOLMODEL_PATCH_VERSION)
+
+
+    SET(PATCH_VERSION_STRING ".${MOLMODEL_PATCH_VERSION}")
+
+
+ENDIF()
+
+
+
+
+
+set(MOLMODEL_VERSION 
+
+
+    "${MOLMODEL_MAJOR_VERSION}.${MOLMODEL_MINOR_VERSION}${PATCH_VERSION_STRING}"
+
+
+    CACHE STRING 
+
+
+    "This is the version that will be built (can't be changed here)." 
+
+
+    FORCE)
+
+
+#set(MOLMODEL_SONAME_VERSION
+
+#    "${MOLMODEL_MAJOR_VERSION}.${MOLMODEL_MINOR_VERSION}"
+
+#    CACHE STRING
+
+#    "Soname version; appended to names of shared libs
+
+#    (can't be changed in GUI)."
+
+#    FORCE)
+
+
+
+#set(SONAME
+
+#    "${MOLMODEL_MAJOR_VERSION}.${MOLMODEL_MINOR_VERSION}"
+
+#    CACHE STRING
+
+#    "Soname version; appended to names of shared libs
+
+#    (can't be changed in GUI)."
+
+#    FORCE)
+
+
+
+
+
+
+# This is the suffix if we're building and depending on versioned libraries.
+
+
+set(VN "_${MOLMODEL_VERSION}")
+
+
+
+
+
+set(BUILD_BINARY_DIR ${CMAKE_BINARY_DIR}
+
+
+    CACHE PATH 
+
+
+    "The Molmodel build (not the install) puts all the libraries and executables together here (with /Release, etc. appended on some platforms).")
+
+
+
+
+
+# Make everything go in the same binary directory. (These are CMake-defined
+
+
+# variables.)
+
+
+set(EXECUTABLE_OUTPUT_PATH ${BUILD_BINARY_DIR})
+
+
+set(LIBRARY_OUTPUT_PATH ${BUILD_BINARY_DIR})
+
+
+
+
+
+# Static libraries, tests, and examples won't be built unless this 
+
+
+# is set.
+
+
+SET(BUILD_STATIC_LIBRARIES FALSE CACHE BOOL
+
+
+"Build '_static' versions of libraries in addition to dynamic libraries?")
+
+
+
+
+
+# Use this to generate a private set of libraries whose names
+
+
+# won't conflict with installed versions.
+
+
+set(BUILD_USING_NAMESPACE "" CACHE STRING
+
+
+	"All library names will be prefixed with 'xxx_' if this is set to xxx.")
+
+
+
+
+
+set(BUILD_UNVERSIONED_LIBRARIES TRUE CACHE BOOL
+
+
+ "Build library names, and assume dependency names, with no version numbers?")
+
+
+
+
+
+set(BUILD_VERSIONED_LIBRARIES FALSE CACHE BOOL
+
+
+ "Build library names, and assume dependency names, with version numbers?")
+
+
+
+
+
+set(NS)
+
+
+if(BUILD_USING_NAMESPACE)
+
+
+    set(NS "${BUILD_USING_NAMESPACE}_")
+
+
+endif()
+
+
+
+
+
+set(MOLMODEL_LIBRARY_NAME ${NS}SimTKmolmodel CACHE STRING
+
+
+"Base name of the library being built; can't be changed here; see BUILD_USING_NAMESPACE variable."
+
+
+FORCE)
+
+
+
+
+
+
+
+
+# Permit use of custom FindOpenMM and FindSimbody modules
+
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")
+
+
+
+
+
+set(CMAKE_VERBOSE_MAKEFILE OFF CACHE BOOL "Control volume of build output" )
+
+
+
+
+
+set(OpenMM_ON OFF)
+
+
+find_package(OpenMM)
+
+
+if(OpenMM_FOUND)
+
+
+    set(OpenMM_ON ON)
+
+
+endif()
+
+
+set(MOLMODEL_USE_OpenMM ${OpenMM_ON} CACHE BOOL
+
+
+    "Control whether Molmodel builds the OpenMM Plugin (requires that OpenMM is installed on the build machine)." )
+
+
+
+
+
+# Caution: this variable is automatically created by the CMake
+
+
+# ENABLE_TESTING() command, but we'll take it over here for
+
+
+# our own purposes too.
+
+
+set(BUILD_TESTING ON CACHE BOOL
+
+
+	"Control building of Molmodel test programs." )
+
+
+
+
+
+set(BUILD_EXAMPLES ON CACHE BOOL
+
+
+	"Control building of Molmodel example programs." )
+
+
+
+
+
+# Turning this off reduces the build time (and space) substantially,
+
+
+# but you may miss the occasional odd bug. Also currently on Windows it
+
+
+# is easier to debug the static tests than the DLL-liked ones.
+
+
+SET( BUILD_TESTING_STATIC ON CACHE BOOL
+
+
+    "If building static libraries, build static test and example programs too?" )
+
+
+
+
+
+SET( BUILD_TESTING_SHARED ON CACHE BOOL
+
+
+    "If building test or example programs, include dynamically-linked ones?" )
+
+
+
+
+
+#
+
+
+# Create a platform name useful for some platform-specific stuff.
+
+
+IF(WIN32)
+
+
+    SET(NATIVE_COPY_CMD copy)
+
+
+ELSEIF(APPLE)
+
+
+    SET(NATIVE_COPY_CMD cp)
+
+
+ELSE()
+
+
+    SET(NATIVE_COPY_CMD cp)
+
+
+ENDIF()
+
+
+
+
+
+# In addition to the platform name we need to know the Application Binary
+
+
+# Interface (ABI) we're building for. Currently that is either x86, meaning
+
+
+# 32 bit Intel instruction set, or x64 for 64 bit Intel instruction set.
+
+
+
+
+
+IF(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
+
+
+    SET(PLATFORM_ABI x64)
+
+
+ELSE()
+
+
+    SET(PLATFORM_ABI x86)
+
+
+ENDIF()
+
+
+
+
+
+SET(BUILD_PLATFORM "${CMAKE_HOST_SYSTEM_NAME}:${PLATFORM_ABI}" CACHE STRING
+
+
+    "This is the platform and ABI we're building for. Not changeable here; use a different CMake generator instead."
+
+
+    FORCE)
+
+
+
+
+
+# Find Simbody using the local FindSimbody.cmake if present.
+
+
+find_package(Simbody REQUIRED)
+
+
+include_directories(${Simbody_INCLUDE_DIR})
+
+
+link_directories(${Simbody_LIB_DIR})
+
+
+
+
+
+# If CMAKE_INSTALL_PREFIX is /usr/local, then the LIBDIR should necessarily be
+
+
+# lib/. Sometimes (on Linux), LIBDIR is something like x86_64-linux-gnu. The
+
+
+# linker will search /usr/lib/x86_64-linux-gnu (this path is in
+
+
+# /etc/ld.so.conf.d), but it will NOT search /usr/local/lib/x86-64-linux-gnu.
+
+
+# HOWEVER, it WILL search /usr/local/lib. So that Linux users needn't modify
+
+
+# their LD_LIBRARY_PATH if installing to /usr/local, we force the LIBDIR to be
+
+
+# lib/.
+
+
+# Note: CMake 3.0 fixes this issue. When we move to CMake 3.0, we can
+
+
+# remove this if-statement. See issue #151.
+
+
+IF("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local" OR
+
+
+        "${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local/")
+
+
+    # Overwrite both of these variables; we use both of them.
+
+
+    SET(CMAKE_INSTALL_LIBDIR "lib")
+
+
+    SET(CMAKE_INSTALL_FULL_LIBDIR
+
+
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+
+
+ENDIF()
+
+
+
+
+
+
+
+
+IF(NOT MSVC AND NOT XCODE AND NOT CMAKE_BUILD_TYPE)
+
+
+    SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING 
+
+
+        "Debug, RelWithDebInfo (recommended), or Release build" 
+
+
+        FORCE)
+
+
+ENDIF()
+
+
+
+
+
+## Choose the maximum level of x86 instruction set that the compiler is 
+
+
+## allowed to use. 
+
+
+## Was using sse2 but changed to let the compilers choose. Most will
+
+
+## probably use sse2 or later by default.
+
+
+## On 64 bit MSVC 2013, the default is sse2 and the argument
+
+
+## isn't recognized so don't specify it.
+
+
+if (CMAKE_CL_64)
+
+
+    set(default_build_inst_set)
+
+
+else()
+
+
+    set(default_build_inst_set)
+
+
+endif()
+
+
+
+
+
+## This can be set to a different value by the person running CMake.
+
+
+SET(BUILD_INST_SET ""
+
+
+    CACHE STRING 
+
+
+    "CPU instruction level compiler is permitted to use (default: let compiler decide).")
+
+
+MARK_AS_ADVANCED( BUILD_INST_SET )
+
+
+
+
+
+if (BUILD_INST_SET)
+
+
+    set(inst_set_to_use ${BUILD_INST_SET})
+
+
+else()
+
+
+    set(inst_set_to_use ${default_build_inst_set})
+
+
+endif()
+
+
+
+
+
+## When building in any of the Release modes, tell gcc/clang to use 
+
+
+## not-quite most agressive optimization.  Here we 
+
+
+## are specifying *all* of the Release flags, overriding CMake's defaults.
+
+
+## Watch out for optimizer bugs in particular gcc versions!
+
+
+
+
+
+IF(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
+
+
+   ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+
+
+
+
+
+    # If using either of these compilers, provide the option of 
+
+
+    # compiling using the c++11 standard.
+
+
+    OPTION(SIMBODY_STANDARD_11
+
+
+        "Compile using the C++11 standard, if using GCC or Clang." ON)
+
+
+    
+
+
+    IF(${SIMBODY_STANDARD_11})
+
+
+        # Using C++11 on OSX requires using libc++ instead of libstd++.
+
+
+        # libc++ is an implementation of the C++ standard library for OSX.
+
+
+        IF(APPLE)
+
+
+            IF(XCODE)
+
+
+                SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
+
+
+                SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+
+
+            ELSE()
+
+
+                SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+
+                SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+
+
+            ENDIF()
+
+
+        ELSE() # not APPLE
+
+
+            SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+
+        ENDIF()
+
+
+    ENDIF()
+
+
+
+
+
+    if (inst_set_to_use)
+
+
+        string(TOLOWER ${inst_set_to_use} GCC_INST_SET)
+
+
+        set(GCC_INST_SET "-m${GCC_INST_SET}")
+
+
+    else()
+
+
+        set(GCC_INST_SET)
+
+
+    endif()
+
+
+
+
+
+    # Get the gcc or clang version number in major.minor.build format
+
+
+    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
+
+
+                    OUTPUT_VARIABLE GCC_VERSION)
+
+
+
+
+
+    # Unrolling fixed-count loops was a useful optimization for Simmatrix
+
+
+    # in earlier gcc versions.
+
+
+    # Doesn't have a big effect for current compiler crop and may be 
+
+
+    # pushing our luck with optimizer bugs. So let the compilers decide
+
+
+    # how to handle loops instead.
+
+
+    ##SET(GCC_OPT_ENABLE "-funroll-loops")
+
+
+
+
+
+    # If you know of optimization bugs that affect Simbody in particular
+
+
+    # gcc versions, this is the place to turn off those optimizations.
+
+
+    SET(GCC_OPT_DISABLE)
+
+
+    # We know Gcc 4.4.3 on Ubuntu 10 is buggy.
+
+
+    IF(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+
+
+      if (GCC_VERSION VERSION_EQUAL 4.4)
+
+
+        SET(GCC_OPT_DISABLE 
+
+
+        "-fno-strict-aliasing -fno-tree-vrp -fno-guess-branch-probability")
+
+
+      endif()
+
+
+    ENDIF()
+
+
+
+
+
+    # C++
+
+
+    SET(BUILD_CXX_FLAGS_DEBUG          "-g ${GCC_INST_SET}")
+
+
+    SET(BUILD_CXX_FLAGS_RELEASE        
+
+
+      "-DNDEBUG -O2 ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")
+
+
+    SET(BUILD_CXX_FLAGS_RELWITHDEBINFO 
+
+
+    "-DNDEBUG -O2 -g ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")
+
+
+    SET(BUILD_CXX_FLAGS_MINSIZEREL     "-DNDEBUG -Os ${GCC_INST_SET}")
+
+
+
+
+
+    # C
+
+
+    SET(BUILD_C_FLAGS_DEBUG            "-g ${GCC_INST_SET}")
+
+
+    SET(BUILD_C_FLAGS_RELEASE          
+
+
+      "-DNDEBUG -O2 ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")
+
+
+    SET(BUILD_C_FLAGS_RELWITHDEBINFO   
+
+
+    "-DNDEBUG -O2 -g ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")
+
+
+    SET(BUILD_C_FLAGS_MINSIZEREL       "-DNDEBUG -Os ${GCC_INST_SET}")
+
+
+
+
+
+    # C++
+
+
+    SET(CMAKE_CXX_FLAGS_DEBUG ${BUILD_CXX_FLAGS_DEBUG}
+
+
+        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
+
+
+    SET(CMAKE_CXX_FLAGS_RELEASE ${BUILD_CXX_FLAGS_RELEASE}
+
+
+        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
+
+
+    SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO ${BUILD_CXX_FLAGS_RELWITHDEBINFO}
+
+
+        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
+
+
+    SET(CMAKE_CXX_FLAGS_MINSIZEREL ${BUILD_CXX_FLAGS_MINSIZEREL}
+
+
+        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
+
+
+
+
+
+    # C
+
+
+    SET(CMAKE_C_FLAGS_DEBUG ${BUILD_C_FLAGS_DEBUG}
+
+
+        CACHE STRING "Can't change here -- see BUILD_C..." FORCE)
+
+
+    SET(CMAKE_C_FLAGS_RELEASE ${BUILD_C_FLAGS_RELEASE}         
+
+
+        CACHE STRING "Can't change here -- see BUILD_C..." FORCE)
+
+
+    SET(CMAKE_C_FLAGS_RELWITHDEBINFO ${BUILD_C_FLAGS_RELWITHDEBINFO}
+
+
+        CACHE STRING "Can't change here -- see BUILD_C..." FORCE)
+
+
+    SET(CMAKE_C_FLAGS_MINSIZEREL ${BUILD_C_FLAGS_MINSIZEREL}
+
+
+        CACHE STRING "Can't change here -- see BUILD_C..." FORCE)
+
+
+
+
+
+ENDIF()
+
+
+
+
+
+## When building in any of the Release modes, tell VC++ cl compiler to use 
+
+
+## intrinsics (i.e. sqrt instruction rather than sqrt subroutine) with 
+
+
+## flag /Oi.
+
+
+## Caution: can't use CMAKE_CXX_COMPILER_ID MATCHES MSVC here because
+
+
+## "MSVC" is a predefined CMAKE variable and will get expanded to 1 or 0
+
+
+IF(MSVC)
+
+
+    if (inst_set_to_use)
+
+
+        string(TOUPPER ${inst_set_to_use} CL_INST_SET)
+
+
+        set(CL_INST_SET "/arch:${CL_INST_SET}")
+
+
+    else()
+
+
+        set(CL_INST_SET)
+
+
+    endif()
+
+
+
+
+
+    set(BUILD_LIMIT_PARALLEL_COMPILES "" CACHE STRING
+
+
+        "Set a maximum number of simultaneous compilations.")
+
+
+    mark_as_advanced(BUILD_LIMIT_PARALLEL_COMPILES)
+
+
+    set(mxcpu ${BUILD_LIMIT_PARALLEL_COMPILES}) # abbreviation
+
+
+
+
+
+    ## C++
+
+
+    SET(BUILD_CXX_FLAGS_DEBUG        
+
+
+    "/D _DEBUG /MDd /Od /Ob0 /RTC1 /Zi /GS- ${CL_INST_SET}")
+
+
+    SET(BUILD_CXX_FLAGS_RELEASE        
+
+
+    "/D NDEBUG /MD  /O2 /Ob2 /Oi /GS- ${CL_INST_SET}")
+
+
+    SET(BUILD_CXX_FLAGS_RELWITHDEBINFO 
+
+
+    "/D NDEBUG /MD  /O2 /Ob2 /Oi /Zi /GS- ${CL_INST_SET}")
+
+
+    SET(BUILD_CXX_FLAGS_MINSIZEREL 
+
+
+    "/D NDEBUG /MD  /O1 /Ob1 /Oi /GS- ${CL_INST_SET}")
+
+
+
+
+
+    ## C
+
+
+    SET(BUILD_C_FLAGS_DEBUG        
+
+
+    "/D _DEBUG /MDd /Od /Ob0 /RTC1 /Zi /GS- ${CL_INST_SET}")
+
+
+    SET(BUILD_C_FLAGS_RELEASE        
+
+
+    "/D NDEBUG /MD  /O2 /Ob2 /Oi /GS- ${CL_INST_SET}")
+
+
+    SET(BUILD_C_FLAGS_RELWITHDEBINFO 
+
+
+    "/D NDEBUG /MD  /O2 /Ob2 /Oi /Zi /GS- ${CL_INST_SET}")
+
+
+    SET(BUILD_C_FLAGS_MINSIZEREL 
+
+
+    "/D NDEBUG /MD  /O1 /Ob1 /Oi /GS- ${CL_INST_SET}")
+
+
+
+
+
+    ## C++
+
+
+    SET(CMAKE_CXX_FLAGS_DEBUG "/MP${mxcpu} ${BUILD_CXX_FLAGS_DEBUG}"
+
+
+        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
+
+
+    SET(CMAKE_CXX_FLAGS_RELEASE "/MP${mxcpu} ${BUILD_CXX_FLAGS_RELEASE}"
+
+
+        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
+
+
+    SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/MP${mxcpu} ${BUILD_CXX_FLAGS_RELWITHDEBINFO}"
+
+
+        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
+
+
+    SET(CMAKE_CXX_FLAGS_MINSIZEREL "/MP${mxcpu} ${BUILD_CXX_FLAGS_MINSIZEREL}"
+
+
+        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
+
+
+
+
+
+    ## C
+
+
+    SET(CMAKE_C_FLAGS_DEBUG "/MP${mxcpu} ${BUILD_C_FLAGS_DEBUG}"
+
+
+        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)
+
+
+    SET(CMAKE_C_FLAGS_RELEASE "/MP${mxcpu} ${BUILD_C_FLAGS_RELEASE}"
+
+
+        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)
+
+
+    SET(CMAKE_C_FLAGS_RELWITHDEBINFO "/MP${mxcpu} ${BUILD_C_FLAGS_RELWITHDEBINFO}"
+
+
+        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)
+
+
+    SET(CMAKE_C_FLAGS_MINSIZEREL "/MP${mxcpu} ${BUILD_C_FLAGS_MINSIZEREL}"
+
+
+        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)
+
+
+
+
+
+ENDIF()
+
+
+
+
+
+# The source is organized into subdirectories, but we handle them all from
+
+
+# this CMakeLists file rather than letting CMake visit them as SUBDIRS.
+
+
+set(MOLMODEL_SOURCE_SUBDIRS .)
+
+
+
+
+
+
+
+
+# Collect up information about the version of the molmodel library we're building
+
+
+# and make it available to the code so it can be built into the binaries.
+
+
+
+
+
+# Get the subversion revision number if we can
+
+
+# It's possible that WIN32 installs use svnversion through cygwin
+
+
+# so we'll try for both svnversion.exe and svnversion. Note that
+
+
+# this will result in warnings if all you have is Tortoise without
+
+
+# Cygwin, and your "about" string will say "unknown" rather than
+
+
+# providing the SVN version of the source.
+
+
+
+
+
+# If there is an actual reason for the SVNVERSION vs. SVNVERSION_EXE
+
+
+# nonsense that was here before, come talk to me.  --Chris Bruns
+
+
+# 1) CMake already understands that Windows executables have ".exe" at the end.
+
+
+# 2) Providing a PATHS argument to find_program is *NOT* hard coding a single path.
+
+
+# Please read the CMake documentation for more details.
+
+
+find_program(SVNVERSION_EXECUTABLE svnversion PATHS "C:/cygwin/bin")
+
+
+if(SVNVERSION_EXECUTABLE)
+
+
+    exec_program(${SVNVERSION_EXECUTABLE}
+
+
+              # Works better on Windows to set working directory rather than
+
+
+              # passing argument to svnversion
+
+
+              ${CMAKE_SOURCE_DIR} # cwd for run
+
+
+              OUTPUT_VARIABLE OUT)
+
+
+    set(MOLMODEL_SVN_REVISION "${OUT}" CACHE STRING "Molmodel svn revision number" FORCE)
+
+
+else(SVNVERSION_EXECUTABLE)
+
+
+    message(STATUS 
+
+
+         "Could not find 'svnversion' executable; 'about' will be wrong. (Cygwin provides one on Windows.)"
+
+
+        )
+
+
+    set(MOLMODEL_SVN_REVISION "unknown" CACHE STRING "Molmodel svn revision number")
+
+
+endif(SVNVERSION_EXECUTABLE)
+
+
+mark_as_advanced(MOLMODEL_SVN_REVISION)
+
+
+
+
+
+# Remove colon from build version, for easier placement in directory names
+
+
+STRING(REPLACE ":" "_" MOLMODEL_SVN_REVISION ${MOLMODEL_SVN_REVISION})
+
+
+
+
+
+ADD_DEFINITIONS(-DSimTK_MOLMODEL_LIBRARY_NAME=${MOLMODEL_LIBRARY_NAME}
+
+
+                -DSimTK_MOLMODEL_MAJOR_VERSION=${MOLMODEL_MAJOR_VERSION}
+
+
+                -DSimTK_MOLMODEL_MINOR_VERSION=${MOLMODEL_MINOR_VERSION}
+
+
+		-DSimTK_MOLMODEL_PATCH_VERSION=${MOLMODEL_PATCH_VERSION})
+
+
+
+
+
+# CMake quotes automatically when building Visual Studio projects but we need
+
+
+# to add them ourselves for Linux or Cygwin. Two cases to avoid duplicate quotes
+
+
+# in Visual Studio which end up in the binary.
+
+
+
+
+
+IF (${CMAKE_GENERATOR} MATCHES "Visual Studio")
+
+
+   SET(NEED_QUOTES FALSE)
+
+
+ELSE (${CMAKE_GENERATOR} MATCHES "Visual Studio")
+
+
+   SET(NEED_QUOTES TRUE)
+
+
+ENDIF (${CMAKE_GENERATOR} MATCHES "Visual Studio")
+
+
+
+
+
+##TODO: doesn't work without quotes in nightly build
+
+
+set(NEED_QUOTES TRUE)
+
+
+
+
+
+IF(NEED_QUOTES)
+
+
+   ADD_DEFINITIONS(-DSimTK_MOLMODEL_SVN_REVISION="${MOLMODEL_SVN_REVISION}"
+
+
+                   -DSimTK_MOLMODEL_COPYRIGHT_YEARS="${MOLMODEL_COPYRIGHT_YEARS}"
+
+
+                   -DSimTK_MOLMODEL_AUTHORS="${MOLMODEL_AUTHORS}")
+
+
+ELSE(NEED_QUOTES)
+
+
+   ADD_DEFINITIONS(-DSimTK_MOLMODEL_SVN_REVISION=${MOLMODEL_SVN_REVISION}
+
+
+                   -DSimTK_MOLMODEL_COPYRIGHT_YEARS=${MOLMODEL_COPYRIGHT_YEARS}
+
+
+                   -DSimTK_MOLMODEL_AUTHORS=${MOLMODEL_AUTHORS})
+
+
+ENDIF(NEED_QUOTES)
+
+
+
+
+
+# -DSimTK_MOLMODEL_TYPE has to be defined in the target subdirectories.
+
+
+# -Dmolmodel_EXPORTS defined automatically when Windows DLL build is being done.
+
+
+
+
+
+set(SHARED_TARGET ${MOLMODEL_LIBRARY_NAME})
+
+
+set(STATIC_TARGET ${MOLMODEL_LIBRARY_NAME}_static)
+
+
+set(SHARED_TARGET_VN ${MOLMODEL_LIBRARY_NAME}${VN})
+
+
+set(STATIC_TARGET_VN ${MOLMODEL_LIBRARY_NAME}${VN}_static)
+
+
+
+
+
+# Ensure that debug libraries have "_d" appended to their names.
+
+
+# CMake gets this right on Windows automatically with this definition.
+
+
+IF (${CMAKE_GENERATOR} MATCHES "Visual Studio")
+
+
+    SET(CMAKE_DEBUG_POSTFIX "_d" CACHE INTERNAL "" FORCE)
+
+
+ENDIF (${CMAKE_GENERATOR} MATCHES "Visual Studio")
+
+
+
+
+
+# But on Unix or Cygwin we have to add the suffix manually
+
+
+IF (UNIX AND CMAKE_BUILD_TYPE MATCHES Debug)
+
+
+    SET(SHARED_TARGET ${SHARED_TARGET}_d)
+
+
+    SET(STATIC_TARGET ${STATIC_TARGET}_d)
+
+
+    SET(SHARED_TARGET_VN ${SHARED_TARGET_VN}_d)
+
+
+    SET(STATIC_TARGET_VN ${STATIC_TARGET_VN}_d)
+
+
+ENDIF (UNIX AND CMAKE_BUILD_TYPE MATCHES Debug)
+
+
+
+
+
+## Test against the unversioned libraries if they are being built;
+
+
+## otherwise against the versioned libraries.
+
+
+IF(BUILD_UNVERSIONED_LIBRARIES)
+
+
+	SET(TEST_SHARED_TARGET ${SHARED_TARGET})
+
+
+	SET(TEST_STATIC_TARGET ${STATIC_TARGET})
+
+
+ELSE(BUILD_UNVERSIONED_LIBRARIES)
+
+
+	SET(TEST_SHARED_TARGET ${SHARED_TARGET_VN})
+
+
+	SET(TEST_STATIC_TARGET ${STATIC_TARGET_VN})
+
+
+ENDIF(BUILD_UNVERSIONED_LIBRARIES)
+
+
+
+
+
+IF(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")
+
+
+    SET(ADDITIONAL_LINK_LIBRARIES)
+
+
+ELSE(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")
+
+
+    ## Assume Microsoft Visual Studio
+
+
+	## ws2_32 is for socket calls in VMD connection
+
+
+    SET(ADDITIONAL_LINK_LIBRARIES ws2_32)
+
+
+ENDIF(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")
+
+
+
+
+
+SET ( USE_GEMMI  TRUE  CACHE BOOL "Should the Gemmi library be linked to the build?" )
+SET ( GEMMI_PATH ""    CACHE PATH "Where is the Gemmi library installed?" )
+
+IF ( USE_GEMMI )
+
+
+	ADD_DEFINITIONS     ( -DGEMMI_USAGE )
+	INCLUDE_DIRECTORIES ( ${GEMMI_PATH} )
+	SET ( ADDITIONAL_LINK_LIBRARIES ${ADDITIONAL_LINK_LIBRARIES} "-lz" )
+
+
+ENDIF ( USE_GEMMI )
+
+
+
+
+
+# These are all the places to search for header files which are
+
+
+# to be part of the API.
+
+
+set(API_INCLUDE_DIRS) # start empty
+
+
+FOREACH(subdir ${MOLMODEL_SOURCE_SUBDIRS})
+
+
+    # append
+
+
+    SET(API_INCLUDE_DIRS ${API_INCLUDE_DIRS}
+
+
+                         ${subdir}/include 
+
+
+                         ${subdir}/include/molmodel 
+
+
+                         ${subdir}/include/molmodel/internal)
+
+
+ENDFOREACH(subdir)
+
+
+
+
+
+# We'll need both *relative* path names, starting with their API_INCLUDE_DIRS,
+
+
+# and absolute pathnames.
+
+
+set(API_REL_INCLUDE_FILES)   # start these out empty
+
+
+set(API_ABS_INCLUDE_FILES)
+
+
+
+
+
+FOREACH(dir ${API_INCLUDE_DIRS})
+
+
+    FILE(GLOB fullpaths ${dir}/*.h)	# returns full pathnames
+
+
+    SET(API_ABS_INCLUDE_FILES ${API_ABS_INCLUDE_FILES} ${fullpaths})
+
+
+
+
+
+    FOREACH(pathname ${fullpaths})
+
+
+        GET_FILENAME_COMPONENT(filename ${pathname} NAME)
+
+
+        SET(API_REL_INCLUDE_FILES ${API_REL_INCLUDE_FILES} ${dir}/${filename})
+
+
+    ENDFOREACH(pathname)
+
+
+ENDFOREACH(dir)
+
+
+
+
+
+# collect up source files
+
+
+set(SOURCE_FILES) # empty
+
+
+set(SOURCE_INCLUDE_FILES)
+
+
+
+
+
+FOREACH(subdir ${MOLMODEL_SOURCE_SUBDIRS})
+
+
+    FILE(GLOB src_files  ${subdir}/src/*.cpp ${subdir}/src/*.c
+
+
+                         ${subdir}/src/*/*.cpp ${subdir}/src/*/*.c)
+
+
+    FILE(GLOB incl_files ${subdir}/src/*.h ${subdir}/src/*/*.h )
+
+
+    SET(SOURCE_FILES         ${SOURCE_FILES}         ${src_files})   #append
+
+
+    SET(SOURCE_INCLUDE_FILES ${SOURCE_INCLUDE_FILES} ${incl_files})
+
+
+
+
+
+    ## Make sure we find these locally before looking in
+
+
+    ## SimTK/include if Molmodel was previously installed there.
+
+
+    INCLUDE_DIRECTORIES(BEFORE ${PROJECT_SOURCE_DIR}/${subdir}/include)
+
+
+ENDFOREACH(subdir)
+
+
+
+
+
+INCLUDE_DIRECTORIES(BEFORE ${PROJECT_SOURCE_DIR}/src)
+
+
+
+
+
+#
+
+
+# Allow automated build and dashboard.
+
+
+#
+
+
+INCLUDE (Dart)
+
+
+
+
+
+IF (BUILD_TESTING)
+
+
+    #IF (UNIX AND NOT CYGWIN AND NOT APPLE)
+
+
+    #  IF (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE MATCHES Debug)
+
+
+    #    ADD_DEFINITIONS(-fprofile-arcs -ftest-coverage)
+
+
+    #    LINK_LIBRARIES(gcov)
+
+
+    #  ENDIF (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE MATCHES Debug)
+
+
+    #ENDIF (UNIX AND NOT CYGWIN AND NOT APPLE)
+
+
+
+
+
+    #
+
+
+    # Testing
+
+
+    #
+
+
+    ENABLE_TESTING()
+
+
+
+
+
+ENDIF (BUILD_TESTING)
+
+
+
+
+
+INCLUDE(ApiDoxygen.cmake)
+
+
+
+
+
+# libraries are installed from their subdirectories; headers here
+
+
+
+
+
+# install headers
+
+
+FILE(GLOB CORE_HEADERS     include/*.h                  */include/*.h)
+
+
+FILE(GLOB TOP_HEADERS      include/molmodel/*.h          */include/molmodel/*.h)
+
+
+FILE(GLOB INTERNAL_HEADERS include/molmodel/internal/*.h */include/molmodel/internal/*.h)
+
+
+INSTALL_FILES(/include/                 FILES ${CORE_HEADERS})
+
+
+INSTALL_FILES(/include/molmodel/         FILES ${TOP_HEADERS})
+
+
+INSTALL_FILES(/include/molmodel/internal FILES ${INTERNAL_HEADERS})
+
+
+
+
+
+# Install documents.
+
+
+FILE(GLOB TOPLEVEL_DOCS doc/*.pdf doc/*.txt)
+
+
+INSTALL(FILES ${TOPLEVEL_DOCS} DESTINATION doc)
+
+
+
+
+
+# These are at the end because we want them processed after
+
+
+# all the various variables have been set above.
+
+
+
+
+
+IF(BUILD_STATIC_LIBRARIES)
+
+
+        ADD_SUBDIRECTORY( staticTarget )
+
+
+ENDIF()
+
+
+ADD_SUBDIRECTORY( sharedTarget )
+
+
+
+
+
+IF (MOLMODEL_USE_OpenMM)
+
+
+    ADD_SUBDIRECTORY( OpenMMPlugin )
+
+
+ENDIF (MOLMODEL_USE_OpenMM)
+
+
+
+
+
+IF( BUILD_EXAMPLES )
+
+
+  ADD_SUBDIRECTORY( examples )
+
+
+ENDIF()
+
+
+
+
+
+IF( BUILD_TESTING )
+
+
+  ADD_SUBDIRECTORY( tests )
+
+
+ENDIF()
+
+
+
+
+
+
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,586 +1,1 @@
-#---------------------------------------------------
-# Molmodel 
-#
-# Creates SimTK library, base name=SimTKmolmodel.
-# Default libraries are shared & optimized. Variants
-# are created for static (_static) and debug (_d) and
-# provision is made for an optional "namespace" (ns)
-# and version number (vn).
-#
-# Windows:
-#   [ns_]SimTKmolmodel[_vn][_d].dll
-#   [ns_]SimTKmolmodel[_vn][_d].lib
-#   [ns_]SimTKmolmodel[_vn]_static[_d].lib
-# Unix:
-#   lib[ns_]SimTKmolmodel[_vn][_d].so
-#   lib[ns_]SimTKmolmodel[_vn]_static[_d].a
-#
-# All libraries are installed in 
-#   %ProgramFiles%\SimTK\lib    (Windows)
-#   /usr/local/SimTK/lib[64]    (Linux, Mac)
-#
-# Also creates an OpenMM plugin DLL that is used at
-# runtime to determine whether OpenMM is available.
-# That DLL is named
-#   OpenMMPlugin[_d].dll
-#   libOpenMMPlugin[_d].so
-#   libOpenMMPlugin[_d].dylib
-# And there is no static version.
-#----------------------------------------------------
-
-cmake_minimum_required(VERSION 2.8)
-
-project(Molmodel)
-
-set(MOLMODEL_MAJOR_VERSION 3)
-set(MOLMODEL_MINOR_VERSION 0)
-set(MOLMODEL_PATCH_VERSION 0)
-
-set(MOLMODEL_COPYRIGHT_YEARS "2006-12")
-
-# underbar separated list of dotted authors, no spaces or commas
-set(MOLMODEL_AUTHORS "Christopher.Bruns_Michael.Sherman")
-
-# Report the version number to the CMake UI. Don't include the 
-# build version if it is zero.
-set(PATCH_VERSION_STRING)
-IF(MOLMODEL_PATCH_VERSION)
-    SET(PATCH_VERSION_STRING ".${MOLMODEL_PATCH_VERSION}")
-ENDIF()
-
-set(MOLMODEL_VERSION 
-    "${MOLMODEL_MAJOR_VERSION}.${MOLMODEL_MINOR_VERSION}${PATCH_VERSION_STRING}"
-    CACHE STRING 
-    "This is the version that will be built (can't be changed here)." 
-    FORCE)
-#set(MOLMODEL_SONAME_VERSION
-#    "${MOLMODEL_MAJOR_VERSION}.${MOLMODEL_MINOR_VERSION}"
-#    CACHE STRING
-#    "Soname version; appended to names of shared libs
-#    (can't be changed in GUI)."
-#    FORCE)
-
-#set(SONAME
-#    "${MOLMODEL_MAJOR_VERSION}.${MOLMODEL_MINOR_VERSION}"
-#    CACHE STRING
-#    "Soname version; appended to names of shared libs
-#    (can't be changed in GUI)."
-#    FORCE)
-
-
-# This is the suffix if we're building and depending on versioned libraries.
-set(VN "_${MOLMODEL_VERSION}")
-
-set(BUILD_BINARY_DIR ${CMAKE_BINARY_DIR}
-    CACHE PATH 
-    "The Molmodel build (not the install) puts all the libraries and executables together here (with /Release, etc. appended on some platforms).")
-
-# Make everything go in the same binary directory. (These are CMake-defined
-# variables.)
-set(EXECUTABLE_OUTPUT_PATH ${BUILD_BINARY_DIR})
-set(LIBRARY_OUTPUT_PATH ${BUILD_BINARY_DIR})
-
-# Static libraries, tests, and examples won't be built unless this 
-# is set.
-SET(BUILD_STATIC_LIBRARIES FALSE CACHE BOOL
-"Build '_static' versions of libraries in addition to dynamic libraries?")
-
-# Use this to generate a private set of libraries whose names
-# won't conflict with installed versions.
-set(BUILD_USING_NAMESPACE "" CACHE STRING
-	"All library names will be prefixed with 'xxx_' if this is set to xxx.")
-
-set(BUILD_UNVERSIONED_LIBRARIES TRUE CACHE BOOL
- "Build library names, and assume dependency names, with no version numbers?")
-
-set(BUILD_VERSIONED_LIBRARIES FALSE CACHE BOOL
- "Build library names, and assume dependency names, with version numbers?")
-
-set(NS)
-if(BUILD_USING_NAMESPACE)
-    set(NS "${BUILD_USING_NAMESPACE}_")
-endif()
-
-set(MOLMODEL_LIBRARY_NAME ${NS}SimTKmolmodel CACHE STRING
-"Base name of the library being built; can't be changed here; see BUILD_USING_NAMESPACE variable."
-FORCE)
-
-
-# Permit use of custom FindOpenMM and FindSimbody modules
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")
-
-set(CMAKE_VERBOSE_MAKEFILE OFF CACHE BOOL "Control volume of build output" )
-
-set(OpenMM_ON OFF)
-find_package(OpenMM)
-if(OpenMM_FOUND)
-    set(OpenMM_ON ON)
-endif()
-set(MOLMODEL_USE_OpenMM ${OpenMM_ON} CACHE BOOL
-    "Control whether Molmodel builds the OpenMM Plugin (requires that OpenMM is installed on the build machine)." )
-
-# Caution: this variable is automatically created by the CMake
-# ENABLE_TESTING() command, but we'll take it over here for
-# our own purposes too.
-set(BUILD_TESTING ON CACHE BOOL
-	"Control building of Molmodel test programs." )
-
-set(BUILD_EXAMPLES ON CACHE BOOL
-	"Control building of Molmodel example programs." )
-
-# Turning this off reduces the build time (and space) substantially,
-# but you may miss the occasional odd bug. Also currently on Windows it
-# is easier to debug the static tests than the DLL-liked ones.
-SET( BUILD_TESTING_STATIC ON CACHE BOOL
-    "If building static libraries, build static test and example programs too?" )
-
-SET( BUILD_TESTING_SHARED ON CACHE BOOL
-    "If building test or example programs, include dynamically-linked ones?" )
-
-#
-# Create a platform name useful for some platform-specific stuff.
-IF(WIN32)
-    SET(NATIVE_COPY_CMD copy)
-ELSEIF(APPLE)
-    SET(NATIVE_COPY_CMD cp)
-ELSE()
-    SET(NATIVE_COPY_CMD cp)
-ENDIF()
-
-# In addition to the platform name we need to know the Application Binary
-# Interface (ABI) we're building for. Currently that is either x86, meaning
-# 32 bit Intel instruction set, or x64 for 64 bit Intel instruction set.
-
-IF(${CMAKE_SIZEOF_VOID_P} EQUAL 8)
-    SET(PLATFORM_ABI x64)
-ELSE()
-    SET(PLATFORM_ABI x86)
-ENDIF()
-
-SET(BUILD_PLATFORM "${CMAKE_HOST_SYSTEM_NAME}:${PLATFORM_ABI}" CACHE STRING
-    "This is the platform and ABI we're building for. Not changeable here; use a different CMake generator instead."
-    FORCE)
-
-# Find Simbody using the local FindSimbody.cmake if present.
-find_package(Simbody REQUIRED)
-include_directories(${Simbody_INCLUDE_DIR})
-link_directories(${Simbody_LIB_DIR})
-
-# If CMAKE_INSTALL_PREFIX is /usr/local, then the LIBDIR should necessarily be
-# lib/. Sometimes (on Linux), LIBDIR is something like x86_64-linux-gnu. The
-# linker will search /usr/lib/x86_64-linux-gnu (this path is in
-# /etc/ld.so.conf.d), but it will NOT search /usr/local/lib/x86-64-linux-gnu.
-# HOWEVER, it WILL search /usr/local/lib. So that Linux users needn't modify
-# their LD_LIBRARY_PATH if installing to /usr/local, we force the LIBDIR to be
-# lib/.
-# Note: CMake 3.0 fixes this issue. When we move to CMake 3.0, we can
-# remove this if-statement. See issue #151.
-IF("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local" OR
-        "${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local/")
-    # Overwrite both of these variables; we use both of them.
-    SET(CMAKE_INSTALL_LIBDIR "lib")
-    SET(CMAKE_INSTALL_FULL_LIBDIR
-        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
-ENDIF()
-
-
-IF(NOT MSVC AND NOT XCODE AND NOT CMAKE_BUILD_TYPE)
-    SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING 
-        "Debug, RelWithDebInfo (recommended), or Release build" 
-        FORCE)
-ENDIF()
-
-## Choose the maximum level of x86 instruction set that the compiler is 
-## allowed to use. 
-## Was using sse2 but changed to let the compilers choose. Most will
-## probably use sse2 or later by default.
-## On 64 bit MSVC 2013, the default is sse2 and the argument
-## isn't recognized so don't specify it.
-if (CMAKE_CL_64)
-    set(default_build_inst_set)
-else()
-    set(default_build_inst_set)
-endif()
-
-## This can be set to a different value by the person running CMake.
-SET(BUILD_INST_SET ""
-    CACHE STRING 
-    "CPU instruction level compiler is permitted to use (default: let compiler decide).")
-MARK_AS_ADVANCED( BUILD_INST_SET )
-
-if (BUILD_INST_SET)
-    set(inst_set_to_use ${BUILD_INST_SET})
-else()
-    set(inst_set_to_use ${default_build_inst_set})
-endif()
-
-## When building in any of the Release modes, tell gcc/clang to use 
-## not-quite most agressive optimization.  Here we 
-## are specifying *all* of the Release flags, overriding CMake's defaults.
-## Watch out for optimizer bugs in particular gcc versions!
-
-IF(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
-   ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-
-    # If using either of these compilers, provide the option of 
-    # compiling using the c++11 standard.
-    OPTION(SIMBODY_STANDARD_11
-        "Compile using the C++11 standard, if using GCC or Clang." ON)
-    
-    IF(${SIMBODY_STANDARD_11})
-        # Using C++11 on OSX requires using libc++ instead of libstd++.
-        # libc++ is an implementation of the C++ standard library for OSX.
-        IF(APPLE)
-            IF(XCODE)
-                SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
-                SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
-            ELSE()
-                SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-                SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-            ENDIF()
-        ELSE() # not APPLE
-            SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-        ENDIF()
-    ENDIF()
-
-    if (inst_set_to_use)
-        string(TOLOWER ${inst_set_to_use} GCC_INST_SET)
-        set(GCC_INST_SET "-m${GCC_INST_SET}")
-    else()
-        set(GCC_INST_SET)
-    endif()
-
-    # Get the gcc or clang version number in major.minor.build format
-    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
-                    OUTPUT_VARIABLE GCC_VERSION)
-
-    # Unrolling fixed-count loops was a useful optimization for Simmatrix
-    # in earlier gcc versions.
-    # Doesn't have a big effect for current compiler crop and may be 
-    # pushing our luck with optimizer bugs. So let the compilers decide
-    # how to handle loops instead.
-    ##SET(GCC_OPT_ENABLE "-funroll-loops")
-
-    # If you know of optimization bugs that affect Simbody in particular
-    # gcc versions, this is the place to turn off those optimizations.
-    SET(GCC_OPT_DISABLE)
-    # We know Gcc 4.4.3 on Ubuntu 10 is buggy.
-    IF(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
-      if (GCC_VERSION VERSION_EQUAL 4.4)
-        SET(GCC_OPT_DISABLE 
-        "-fno-strict-aliasing -fno-tree-vrp -fno-guess-branch-probability")
-      endif()
-    ENDIF()
-
-    # C++
-    SET(BUILD_CXX_FLAGS_DEBUG          "-g ${GCC_INST_SET}")
-    SET(BUILD_CXX_FLAGS_RELEASE        
-      "-DNDEBUG -O2 ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")
-    SET(BUILD_CXX_FLAGS_RELWITHDEBINFO 
-    "-DNDEBUG -O2 -g ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")
-    SET(BUILD_CXX_FLAGS_MINSIZEREL     "-DNDEBUG -Os ${GCC_INST_SET}")
-
-    # C
-    SET(BUILD_C_FLAGS_DEBUG            "-g ${GCC_INST_SET}")
-    SET(BUILD_C_FLAGS_RELEASE          
-      "-DNDEBUG -O2 ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")
-    SET(BUILD_C_FLAGS_RELWITHDEBINFO   
-    "-DNDEBUG -O2 -g ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")
-    SET(BUILD_C_FLAGS_MINSIZEREL       "-DNDEBUG -Os ${GCC_INST_SET}")
-
-    # C++
-    SET(CMAKE_CXX_FLAGS_DEBUG ${BUILD_CXX_FLAGS_DEBUG}
-        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
-    SET(CMAKE_CXX_FLAGS_RELEASE ${BUILD_CXX_FLAGS_RELEASE}
-        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
-    SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO ${BUILD_CXX_FLAGS_RELWITHDEBINFO}
-        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
-    SET(CMAKE_CXX_FLAGS_MINSIZEREL ${BUILD_CXX_FLAGS_MINSIZEREL}
-        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
-
-    # C
-    SET(CMAKE_C_FLAGS_DEBUG ${BUILD_C_FLAGS_DEBUG}
-        CACHE STRING "Can't change here -- see BUILD_C..." FORCE)
-    SET(CMAKE_C_FLAGS_RELEASE ${BUILD_C_FLAGS_RELEASE}         
-        CACHE STRING "Can't change here -- see BUILD_C..." FORCE)
-    SET(CMAKE_C_FLAGS_RELWITHDEBINFO ${BUILD_C_FLAGS_RELWITHDEBINFO}
-        CACHE STRING "Can't change here -- see BUILD_C..." FORCE)
-    SET(CMAKE_C_FLAGS_MINSIZEREL ${BUILD_C_FLAGS_MINSIZEREL}
-        CACHE STRING "Can't change here -- see BUILD_C..." FORCE)
-
-ENDIF()
-
-## When building in any of the Release modes, tell VC++ cl compiler to use 
-## intrinsics (i.e. sqrt instruction rather than sqrt subroutine) with 
-## flag /Oi.
-## Caution: can't use CMAKE_CXX_COMPILER_ID MATCHES MSVC here because
-## "MSVC" is a predefined CMAKE variable and will get expanded to 1 or 0
-IF(MSVC)
-    if (inst_set_to_use)
-        string(TOUPPER ${inst_set_to_use} CL_INST_SET)
-        set(CL_INST_SET "/arch:${CL_INST_SET}")
-    else()
-        set(CL_INST_SET)
-    endif()
-
-    set(BUILD_LIMIT_PARALLEL_COMPILES "" CACHE STRING
-        "Set a maximum number of simultaneous compilations.")
-    mark_as_advanced(BUILD_LIMIT_PARALLEL_COMPILES)
-    set(mxcpu ${BUILD_LIMIT_PARALLEL_COMPILES}) # abbreviation
-
-    ## C++
-    SET(BUILD_CXX_FLAGS_DEBUG        
-    "/D _DEBUG /MDd /Od /Ob0 /RTC1 /Zi /GS- ${CL_INST_SET}")
-    SET(BUILD_CXX_FLAGS_RELEASE        
-    "/D NDEBUG /MD  /O2 /Ob2 /Oi /GS- ${CL_INST_SET}")
-    SET(BUILD_CXX_FLAGS_RELWITHDEBINFO 
-    "/D NDEBUG /MD  /O2 /Ob2 /Oi /Zi /GS- ${CL_INST_SET}")
-    SET(BUILD_CXX_FLAGS_MINSIZEREL 
-    "/D NDEBUG /MD  /O1 /Ob1 /Oi /GS- ${CL_INST_SET}")
-
-    ## C
-    SET(BUILD_C_FLAGS_DEBUG        
-    "/D _DEBUG /MDd /Od /Ob0 /RTC1 /Zi /GS- ${CL_INST_SET}")
-    SET(BUILD_C_FLAGS_RELEASE        
-    "/D NDEBUG /MD  /O2 /Ob2 /Oi /GS- ${CL_INST_SET}")
-    SET(BUILD_C_FLAGS_RELWITHDEBINFO 
-    "/D NDEBUG /MD  /O2 /Ob2 /Oi /Zi /GS- ${CL_INST_SET}")
-    SET(BUILD_C_FLAGS_MINSIZEREL 
-    "/D NDEBUG /MD  /O1 /Ob1 /Oi /GS- ${CL_INST_SET}")
-
-    ## C++
-    SET(CMAKE_CXX_FLAGS_DEBUG "/MP${mxcpu} ${BUILD_CXX_FLAGS_DEBUG}"
-        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
-    SET(CMAKE_CXX_FLAGS_RELEASE "/MP${mxcpu} ${BUILD_CXX_FLAGS_RELEASE}"
-        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
-    SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/MP${mxcpu} ${BUILD_CXX_FLAGS_RELWITHDEBINFO}"
-        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
-    SET(CMAKE_CXX_FLAGS_MINSIZEREL "/MP${mxcpu} ${BUILD_CXX_FLAGS_MINSIZEREL}"
-        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)
-
-    ## C
-    SET(CMAKE_C_FLAGS_DEBUG "/MP${mxcpu} ${BUILD_C_FLAGS_DEBUG}"
-        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)
-    SET(CMAKE_C_FLAGS_RELEASE "/MP${mxcpu} ${BUILD_C_FLAGS_RELEASE}"
-        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)
-    SET(CMAKE_C_FLAGS_RELWITHDEBINFO "/MP${mxcpu} ${BUILD_C_FLAGS_RELWITHDEBINFO}"
-        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)
-    SET(CMAKE_C_FLAGS_MINSIZEREL "/MP${mxcpu} ${BUILD_C_FLAGS_MINSIZEREL}"
-        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)
-
-ENDIF()
-
-# The source is organized into subdirectories, but we handle them all from
-# this CMakeLists file rather than letting CMake visit them as SUBDIRS.
-set(MOLMODEL_SOURCE_SUBDIRS .)
-
-
-# Collect up information about the version of the molmodel library we're building
-# and make it available to the code so it can be built into the binaries.
-
-# Get the subversion revision number if we can
-# It's possible that WIN32 installs use svnversion through cygwin
-# so we'll try for both svnversion.exe and svnversion. Note that
-# this will result in warnings if all you have is Tortoise without
-# Cygwin, and your "about" string will say "unknown" rather than
-# providing the SVN version of the source.
-
-# If there is an actual reason for the SVNVERSION vs. SVNVERSION_EXE
-# nonsense that was here before, come talk to me.  --Chris Bruns
-# 1) CMake already understands that Windows executables have ".exe" at the end.
-# 2) Providing a PATHS argument to find_program is *NOT* hard coding a single path.
-# Please read the CMake documentation for more details.
-find_program(SVNVERSION_EXECUTABLE svnversion PATHS "C:/cygwin/bin")
-if(SVNVERSION_EXECUTABLE)
-    exec_program(${SVNVERSION_EXECUTABLE}
-              # Works better on Windows to set working directory rather than
-              # passing argument to svnversion
-              ${CMAKE_SOURCE_DIR} # cwd for run
-              OUTPUT_VARIABLE OUT)
-    set(MOLMODEL_SVN_REVISION "${OUT}" CACHE STRING "Molmodel svn revision number" FORCE)
-else(SVNVERSION_EXECUTABLE)
-    message(STATUS 
-         "Could not find 'svnversion' executable; 'about' will be wrong. (Cygwin provides one on Windows.)"
-        )
-    set(MOLMODEL_SVN_REVISION "unknown" CACHE STRING "Molmodel svn revision number")
-endif(SVNVERSION_EXECUTABLE)
-mark_as_advanced(MOLMODEL_SVN_REVISION)
-
-# Remove colon from build version, for easier placement in directory names
-STRING(REPLACE ":" "_" MOLMODEL_SVN_REVISION ${MOLMODEL_SVN_REVISION})
-
-ADD_DEFINITIONS(-DSimTK_MOLMODEL_LIBRARY_NAME=${MOLMODEL_LIBRARY_NAME}
-                -DSimTK_MOLMODEL_MAJOR_VERSION=${MOLMODEL_MAJOR_VERSION}
-                -DSimTK_MOLMODEL_MINOR_VERSION=${MOLMODEL_MINOR_VERSION}
-		-DSimTK_MOLMODEL_PATCH_VERSION=${MOLMODEL_PATCH_VERSION})
-
-# CMake quotes automatically when building Visual Studio projects but we need
-# to add them ourselves for Linux or Cygwin. Two cases to avoid duplicate quotes
-# in Visual Studio which end up in the binary.
-
-IF (${CMAKE_GENERATOR} MATCHES "Visual Studio")
-   SET(NEED_QUOTES FALSE)
-ELSE (${CMAKE_GENERATOR} MATCHES "Visual Studio")
-   SET(NEED_QUOTES TRUE)
-ENDIF (${CMAKE_GENERATOR} MATCHES "Visual Studio")
-
-##TODO: doesn't work without quotes in nightly build
-set(NEED_QUOTES TRUE)
-
-IF(NEED_QUOTES)
-   ADD_DEFINITIONS(-DSimTK_MOLMODEL_SVN_REVISION="${MOLMODEL_SVN_REVISION}"
-                   -DSimTK_MOLMODEL_COPYRIGHT_YEARS="${MOLMODEL_COPYRIGHT_YEARS}"
-                   -DSimTK_MOLMODEL_AUTHORS="${MOLMODEL_AUTHORS}")
-ELSE(NEED_QUOTES)
-   ADD_DEFINITIONS(-DSimTK_MOLMODEL_SVN_REVISION=${MOLMODEL_SVN_REVISION}
-                   -DSimTK_MOLMODEL_COPYRIGHT_YEARS=${MOLMODEL_COPYRIGHT_YEARS}
-                   -DSimTK_MOLMODEL_AUTHORS=${MOLMODEL_AUTHORS})
-ENDIF(NEED_QUOTES)
-
-# -DSimTK_MOLMODEL_TYPE has to be defined in the target subdirectories.
-# -Dmolmodel_EXPORTS defined automatically when Windows DLL build is being done.
-
-set(SHARED_TARGET ${MOLMODEL_LIBRARY_NAME})
-set(STATIC_TARGET ${MOLMODEL_LIBRARY_NAME}_static)
-set(SHARED_TARGET_VN ${MOLMODEL_LIBRARY_NAME}${VN})
-set(STATIC_TARGET_VN ${MOLMODEL_LIBRARY_NAME}${VN}_static)
-
-# Ensure that debug libraries have "_d" appended to their names.
-# CMake gets this right on Windows automatically with this definition.
-IF (${CMAKE_GENERATOR} MATCHES "Visual Studio")
-    SET(CMAKE_DEBUG_POSTFIX "_d" CACHE INTERNAL "" FORCE)
-ENDIF (${CMAKE_GENERATOR} MATCHES "Visual Studio")
-
-# But on Unix or Cygwin we have to add the suffix manually
-IF (UNIX AND CMAKE_BUILD_TYPE MATCHES Debug)
-    SET(SHARED_TARGET ${SHARED_TARGET}_d)
-    SET(STATIC_TARGET ${STATIC_TARGET}_d)
-    SET(SHARED_TARGET_VN ${SHARED_TARGET_VN}_d)
-    SET(STATIC_TARGET_VN ${STATIC_TARGET_VN}_d)
-ENDIF (UNIX AND CMAKE_BUILD_TYPE MATCHES Debug)
-
-## Test against the unversioned libraries if they are being built;
-## otherwise against the versioned libraries.
-IF(BUILD_UNVERSIONED_LIBRARIES)
-	SET(TEST_SHARED_TARGET ${SHARED_TARGET})
-	SET(TEST_STATIC_TARGET ${STATIC_TARGET})
-ELSE(BUILD_UNVERSIONED_LIBRARIES)
-	SET(TEST_SHARED_TARGET ${SHARED_TARGET_VN})
-	SET(TEST_STATIC_TARGET ${STATIC_TARGET_VN})
-ENDIF(BUILD_UNVERSIONED_LIBRARIES)
-
-IF(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")
-    SET(ADDITIONAL_LINK_LIBRARIES)
-ELSE(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")
-    ## Assume Microsoft Visual Studio
-	## ws2_32 is for socket calls in VMD connection
-    SET(ADDITIONAL_LINK_LIBRARIES ws2_32)
-ENDIF(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")
-
-SET ( ADD_MMDB2_LIBRARY TRUE  CACHE BOOL "Should the MMDB2 library be linked to the build?" )
-IF ( ADD_MMDB2_LIBRARY )
-	SET ( ADDITIONAL_LINK_LIBRARIES ${ADDITIONAL_LINK_LIBRARIES} "-lmmdb2" )
-	ADD_DEFINITIONS     ( -DMMDB2_LIB_USAGE )
-ENDIF ( ADD_MMDB2_LIBRARY )
-
-# These are all the places to search for header files which are
-# to be part of the API.
-set(API_INCLUDE_DIRS) # start empty
-FOREACH(subdir ${MOLMODEL_SOURCE_SUBDIRS})
-    # append
-    SET(API_INCLUDE_DIRS ${API_INCLUDE_DIRS}
-                         ${subdir}/include 
-                         ${subdir}/include/molmodel 
-                         ${subdir}/include/molmodel/internal)
-ENDFOREACH(subdir)
-
-# We'll need both *relative* path names, starting with their API_INCLUDE_DIRS,
-# and absolute pathnames.
-set(API_REL_INCLUDE_FILES)   # start these out empty
-set(API_ABS_INCLUDE_FILES)
-
-FOREACH(dir ${API_INCLUDE_DIRS})
-    FILE(GLOB fullpaths ${dir}/*.h)	# returns full pathnames
-    SET(API_ABS_INCLUDE_FILES ${API_ABS_INCLUDE_FILES} ${fullpaths})
-
-    FOREACH(pathname ${fullpaths})
-        GET_FILENAME_COMPONENT(filename ${pathname} NAME)
-        SET(API_REL_INCLUDE_FILES ${API_REL_INCLUDE_FILES} ${dir}/${filename})
-    ENDFOREACH(pathname)
-ENDFOREACH(dir)
-
-# collect up source files
-set(SOURCE_FILES) # empty
-set(SOURCE_INCLUDE_FILES)
-
-FOREACH(subdir ${MOLMODEL_SOURCE_SUBDIRS})
-    FILE(GLOB src_files  ${subdir}/src/*.cpp ${subdir}/src/*.c
-                         ${subdir}/src/*/*.cpp ${subdir}/src/*/*.c)
-    FILE(GLOB incl_files ${subdir}/src/*.h ${subdir}/src/*/*.h )
-    SET(SOURCE_FILES         ${SOURCE_FILES}         ${src_files})   #append
-    SET(SOURCE_INCLUDE_FILES ${SOURCE_INCLUDE_FILES} ${incl_files})
-
-    ## Make sure we find these locally before looking in
-    ## SimTK/include if Molmodel was previously installed there.
-    INCLUDE_DIRECTORIES(BEFORE ${PROJECT_SOURCE_DIR}/${subdir}/include)
-ENDFOREACH(subdir)
-
-INCLUDE_DIRECTORIES(BEFORE ${PROJECT_SOURCE_DIR}/src)
-
-#
-# Allow automated build and dashboard.
-#
-INCLUDE (Dart)
-
-IF (BUILD_TESTING)
-    #IF (UNIX AND NOT CYGWIN AND NOT APPLE)
-    #  IF (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE MATCHES Debug)
-    #    ADD_DEFINITIONS(-fprofile-arcs -ftest-coverage)
-    #    LINK_LIBRARIES(gcov)
-    #  ENDIF (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE MATCHES Debug)
-    #ENDIF (UNIX AND NOT CYGWIN AND NOT APPLE)
-
-    #
-    # Testing
-    #
-    ENABLE_TESTING()
-
-ENDIF (BUILD_TESTING)
-
-INCLUDE(ApiDoxygen.cmake)
-
-# libraries are installed from their subdirectories; headers here
-
-# install headers
-FILE(GLOB CORE_HEADERS     include/*.h                  */include/*.h)
-FILE(GLOB TOP_HEADERS      include/molmodel/*.h          */include/molmodel/*.h)
-FILE(GLOB INTERNAL_HEADERS include/molmodel/internal/*.h */include/molmodel/internal/*.h)
-INSTALL_FILES(/include/                 FILES ${CORE_HEADERS})
-INSTALL_FILES(/include/molmodel/         FILES ${TOP_HEADERS})
-INSTALL_FILES(/include/molmodel/internal FILES ${INTERNAL_HEADERS})
-
-# Install documents.
-FILE(GLOB TOPLEVEL_DOCS doc/*.pdf doc/*.txt)
-INSTALL(FILES ${TOPLEVEL_DOCS} DESTINATION doc)
-
-# These are at the end because we want them processed after
-# all the various variables have been set above.
-
-IF(BUILD_STATIC_LIBRARIES)
-        ADD_SUBDIRECTORY( staticTarget )
-ENDIF()
-ADD_SUBDIRECTORY( sharedTarget )
-
-IF (MOLMODEL_USE_OpenMM)
-    ADD_SUBDIRECTORY( OpenMMPlugin )
-ENDIF (MOLMODEL_USE_OpenMM)
-
-IF( BUILD_EXAMPLES )
-  ADD_SUBDIRECTORY( examples )
-ENDIF()
-
-IF( BUILD_TESTING )
-  ADD_SUBDIRECTORY( tests )
-ENDIF()
-
-
+#---------------------------------------------------# Molmodel ## Creates SimTK library, base name=SimTKmolmodel.# Default libraries are shared & optimized. Variants# are created for static (_static) and debug (_d) and# provision is made for an optional "namespace" (ns)# and version number (vn).## Windows:#   [ns_]SimTKmolmodel[_vn][_d].dll#   [ns_]SimTKmolmodel[_vn][_d].lib#   [ns_]SimTKmolmodel[_vn]_static[_d].lib# Unix:#   lib[ns_]SimTKmolmodel[_vn][_d].so#   lib[ns_]SimTKmolmodel[_vn]_static[_d].a## All libraries are installed in #   %ProgramFiles%\SimTK\lib    (Windows)#   /usr/local/SimTK/lib[64]    (Linux, Mac)## Also creates an OpenMM plugin DLL that is used at# runtime to determine whether OpenMM is available.# That DLL is named#   OpenMMPlugin[_d].dll#   libOpenMMPlugin[_d].so#   libOpenMMPlugin[_d].dylib# And there is no static version.#----------------------------------------------------cmake_minimum_required(VERSION 2.8)project(Molmodel)set(MOLMODEL_MAJOR_VERSION 3)set(MOLMODEL_MINOR_VERSION 0)set(MOLMODEL_PATCH_VERSION 0)set(MOLMODEL_COPYRIGHT_YEARS "2006-12")# underbar separated list of dotted authors, no spaces or commasset(MOLMODEL_AUTHORS "Christopher.Bruns_Michael.Sherman")# Report the version number to the CMake UI. Don't include the # build version if it is zero.set(PATCH_VERSION_STRING)IF(MOLMODEL_PATCH_VERSION)    SET(PATCH_VERSION_STRING ".${MOLMODEL_PATCH_VERSION}")ENDIF()set(MOLMODEL_VERSION     "${MOLMODEL_MAJOR_VERSION}.${MOLMODEL_MINOR_VERSION}${PATCH_VERSION_STRING}"    CACHE STRING     "This is the version that will be built (can't be changed here)."     FORCE)#set(MOLMODEL_SONAME_VERSION#    "${MOLMODEL_MAJOR_VERSION}.${MOLMODEL_MINOR_VERSION}"#    CACHE STRING#    "Soname version; appended to names of shared libs#    (can't be changed in GUI)."#    FORCE)#set(SONAME#    "${MOLMODEL_MAJOR_VERSION}.${MOLMODEL_MINOR_VERSION}"#    CACHE STRING#    "Soname version; appended to names of shared libs#    (can't be changed in GUI)."#    FORCE)# This is the suffix if we're building and depending on versioned libraries.set(VN "_${MOLMODEL_VERSION}")set(BUILD_BINARY_DIR ${CMAKE_BINARY_DIR}    CACHE PATH     "The Molmodel build (not the install) puts all the libraries and executables together here (with /Release, etc. appended on some platforms).")# Make everything go in the same binary directory. (These are CMake-defined# variables.)set(EXECUTABLE_OUTPUT_PATH ${BUILD_BINARY_DIR})set(LIBRARY_OUTPUT_PATH ${BUILD_BINARY_DIR})# Static libraries, tests, and examples won't be built unless this # is set.SET(BUILD_STATIC_LIBRARIES FALSE CACHE BOOL"Build '_static' versions of libraries in addition to dynamic libraries?")# Use this to generate a private set of libraries whose names# won't conflict with installed versions.set(BUILD_USING_NAMESPACE "" CACHE STRING	"All library names will be prefixed with 'xxx_' if this is set to xxx.")set(BUILD_UNVERSIONED_LIBRARIES TRUE CACHE BOOL "Build library names, and assume dependency names, with no version numbers?")set(BUILD_VERSIONED_LIBRARIES FALSE CACHE BOOL "Build library names, and assume dependency names, with version numbers?")set(NS)if(BUILD_USING_NAMESPACE)    set(NS "${BUILD_USING_NAMESPACE}_")endif()set(MOLMODEL_LIBRARY_NAME ${NS}SimTKmolmodel CACHE STRING"Base name of the library being built; can't be changed here; see BUILD_USING_NAMESPACE variable."FORCE)# Permit use of custom FindOpenMM and FindSimbody modulesset(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")set(CMAKE_VERBOSE_MAKEFILE OFF CACHE BOOL "Control volume of build output" )set(OpenMM_ON OFF)find_package(OpenMM)if(OpenMM_FOUND)    set(OpenMM_ON ON)endif()set(MOLMODEL_USE_OpenMM ${OpenMM_ON} CACHE BOOL    "Control whether Molmodel builds the OpenMM Plugin (requires that OpenMM is installed on the build machine)." )# Caution: this variable is automatically created by the CMake# ENABLE_TESTING() command, but we'll take it over here for# our own purposes too.set(BUILD_TESTING ON CACHE BOOL	"Control building of Molmodel test programs." )set(BUILD_EXAMPLES ON CACHE BOOL	"Control building of Molmodel example programs." )# Turning this off reduces the build time (and space) substantially,# but you may miss the occasional odd bug. Also currently on Windows it# is easier to debug the static tests than the DLL-liked ones.SET( BUILD_TESTING_STATIC ON CACHE BOOL    "If building static libraries, build static test and example programs too?" )SET( BUILD_TESTING_SHARED ON CACHE BOOL    "If building test or example programs, include dynamically-linked ones?" )## Create a platform name useful for some platform-specific stuff.IF(WIN32)    SET(NATIVE_COPY_CMD copy)ELSEIF(APPLE)    SET(NATIVE_COPY_CMD cp)ELSE()    SET(NATIVE_COPY_CMD cp)ENDIF()# In addition to the platform name we need to know the Application Binary# Interface (ABI) we're building for. Currently that is either x86, meaning# 32 bit Intel instruction set, or x64 for 64 bit Intel instruction set.IF(${CMAKE_SIZEOF_VOID_P} EQUAL 8)    SET(PLATFORM_ABI x64)ELSE()    SET(PLATFORM_ABI x86)ENDIF()SET(BUILD_PLATFORM "${CMAKE_HOST_SYSTEM_NAME}:${PLATFORM_ABI}" CACHE STRING    "This is the platform and ABI we're building for. Not changeable here; use a different CMake generator instead."    FORCE)# Find Simbody using the local FindSimbody.cmake if present.find_package(Simbody REQUIRED)include_directories(${Simbody_INCLUDE_DIR})link_directories(${Simbody_LIB_DIR})# If CMAKE_INSTALL_PREFIX is /usr/local, then the LIBDIR should necessarily be# lib/. Sometimes (on Linux), LIBDIR is something like x86_64-linux-gnu. The# linker will search /usr/lib/x86_64-linux-gnu (this path is in# /etc/ld.so.conf.d), but it will NOT search /usr/local/lib/x86-64-linux-gnu.# HOWEVER, it WILL search /usr/local/lib. So that Linux users needn't modify# their LD_LIBRARY_PATH if installing to /usr/local, we force the LIBDIR to be# lib/.# Note: CMake 3.0 fixes this issue. When we move to CMake 3.0, we can# remove this if-statement. See issue #151.IF("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local" OR        "${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr/local/")    # Overwrite both of these variables; we use both of them.    SET(CMAKE_INSTALL_LIBDIR "lib")    SET(CMAKE_INSTALL_FULL_LIBDIR        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")ENDIF()IF(NOT MSVC AND NOT XCODE AND NOT CMAKE_BUILD_TYPE)    SET(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING         "Debug, RelWithDebInfo (recommended), or Release build"         FORCE)ENDIF()## Choose the maximum level of x86 instruction set that the compiler is ## allowed to use. ## Was using sse2 but changed to let the compilers choose. Most will## probably use sse2 or later by default.## On 64 bit MSVC 2013, the default is sse2 and the argument## isn't recognized so don't specify it.if (CMAKE_CL_64)    set(default_build_inst_set)else()    set(default_build_inst_set)endif()## This can be set to a different value by the person running CMake.SET(BUILD_INST_SET ""    CACHE STRING     "CPU instruction level compiler is permitted to use (default: let compiler decide).")MARK_AS_ADVANCED( BUILD_INST_SET )if (BUILD_INST_SET)    set(inst_set_to_use ${BUILD_INST_SET})else()    set(inst_set_to_use ${default_build_inst_set})endif()## When building in any of the Release modes, tell gcc/clang to use ## not-quite most agressive optimization.  Here we ## are specifying *all* of the Release flags, overriding CMake's defaults.## Watch out for optimizer bugs in particular gcc versions!IF(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR   ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")    # If using either of these compilers, provide the option of     # compiling using the c++11 standard.    OPTION(SIMBODY_STANDARD_11        "Compile using the C++11 standard, if using GCC or Clang." ON)        IF(${SIMBODY_STANDARD_11})        # Using C++11 on OSX requires using libc++ instead of libstd++.        # libc++ is an implementation of the C++ standard library for OSX.        IF(APPLE)            IF(XCODE)                SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")                SET(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")            ELSE()                SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")                SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")            ENDIF()        ELSE() # not APPLE            SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")        ENDIF()    ENDIF()    if (inst_set_to_use)        string(TOLOWER ${inst_set_to_use} GCC_INST_SET)        set(GCC_INST_SET "-m${GCC_INST_SET}")    else()        set(GCC_INST_SET)    endif()    # Get the gcc or clang version number in major.minor.build format    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion                    OUTPUT_VARIABLE GCC_VERSION)    # Unrolling fixed-count loops was a useful optimization for Simmatrix    # in earlier gcc versions.    # Doesn't have a big effect for current compiler crop and may be     # pushing our luck with optimizer bugs. So let the compilers decide    # how to handle loops instead.    ##SET(GCC_OPT_ENABLE "-funroll-loops")    # If you know of optimization bugs that affect Simbody in particular    # gcc versions, this is the place to turn off those optimizations.    SET(GCC_OPT_DISABLE)    # We know Gcc 4.4.3 on Ubuntu 10 is buggy.    IF(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")      if (GCC_VERSION VERSION_EQUAL 4.4)        SET(GCC_OPT_DISABLE         "-fno-strict-aliasing -fno-tree-vrp -fno-guess-branch-probability")      endif()    ENDIF()    # C++    SET(BUILD_CXX_FLAGS_DEBUG          "-g ${GCC_INST_SET}")    SET(BUILD_CXX_FLAGS_RELEASE              "-DNDEBUG -O2 ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")    SET(BUILD_CXX_FLAGS_RELWITHDEBINFO     "-DNDEBUG -O2 -g ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")    SET(BUILD_CXX_FLAGS_MINSIZEREL     "-DNDEBUG -Os ${GCC_INST_SET}")    # C    SET(BUILD_C_FLAGS_DEBUG            "-g ${GCC_INST_SET}")    SET(BUILD_C_FLAGS_RELEASE                "-DNDEBUG -O2 ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")    SET(BUILD_C_FLAGS_RELWITHDEBINFO       "-DNDEBUG -O2 -g ${GCC_OPT_ENABLE} ${GCC_OPT_DISABLE} ${GCC_INST_SET}")    SET(BUILD_C_FLAGS_MINSIZEREL       "-DNDEBUG -Os ${GCC_INST_SET}")    # C++    SET(CMAKE_CXX_FLAGS_DEBUG ${BUILD_CXX_FLAGS_DEBUG}        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    SET(CMAKE_CXX_FLAGS_RELEASE ${BUILD_CXX_FLAGS_RELEASE}        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO ${BUILD_CXX_FLAGS_RELWITHDEBINFO}        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    SET(CMAKE_CXX_FLAGS_MINSIZEREL ${BUILD_CXX_FLAGS_MINSIZEREL}        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    # C    SET(CMAKE_C_FLAGS_DEBUG ${BUILD_C_FLAGS_DEBUG}        CACHE STRING "Can't change here -- see BUILD_C..." FORCE)    SET(CMAKE_C_FLAGS_RELEASE ${BUILD_C_FLAGS_RELEASE}                 CACHE STRING "Can't change here -- see BUILD_C..." FORCE)    SET(CMAKE_C_FLAGS_RELWITHDEBINFO ${BUILD_C_FLAGS_RELWITHDEBINFO}        CACHE STRING "Can't change here -- see BUILD_C..." FORCE)    SET(CMAKE_C_FLAGS_MINSIZEREL ${BUILD_C_FLAGS_MINSIZEREL}        CACHE STRING "Can't change here -- see BUILD_C..." FORCE)ENDIF()## When building in any of the Release modes, tell VC++ cl compiler to use ## intrinsics (i.e. sqrt instruction rather than sqrt subroutine) with ## flag /Oi.## Caution: can't use CMAKE_CXX_COMPILER_ID MATCHES MSVC here because## "MSVC" is a predefined CMAKE variable and will get expanded to 1 or 0IF(MSVC)    if (inst_set_to_use)        string(TOUPPER ${inst_set_to_use} CL_INST_SET)        set(CL_INST_SET "/arch:${CL_INST_SET}")    else()        set(CL_INST_SET)    endif()    set(BUILD_LIMIT_PARALLEL_COMPILES "" CACHE STRING        "Set a maximum number of simultaneous compilations.")    mark_as_advanced(BUILD_LIMIT_PARALLEL_COMPILES)    set(mxcpu ${BUILD_LIMIT_PARALLEL_COMPILES}) # abbreviation    ## C++    SET(BUILD_CXX_FLAGS_DEBUG            "/D _DEBUG /MDd /Od /Ob0 /RTC1 /Zi /GS- ${CL_INST_SET}")    SET(BUILD_CXX_FLAGS_RELEASE            "/D NDEBUG /MD  /O2 /Ob2 /Oi /GS- ${CL_INST_SET}")    SET(BUILD_CXX_FLAGS_RELWITHDEBINFO     "/D NDEBUG /MD  /O2 /Ob2 /Oi /Zi /GS- ${CL_INST_SET}")    SET(BUILD_CXX_FLAGS_MINSIZEREL     "/D NDEBUG /MD  /O1 /Ob1 /Oi /GS- ${CL_INST_SET}")    ## C    SET(BUILD_C_FLAGS_DEBUG            "/D _DEBUG /MDd /Od /Ob0 /RTC1 /Zi /GS- ${CL_INST_SET}")    SET(BUILD_C_FLAGS_RELEASE            "/D NDEBUG /MD  /O2 /Ob2 /Oi /GS- ${CL_INST_SET}")    SET(BUILD_C_FLAGS_RELWITHDEBINFO     "/D NDEBUG /MD  /O2 /Ob2 /Oi /Zi /GS- ${CL_INST_SET}")    SET(BUILD_C_FLAGS_MINSIZEREL     "/D NDEBUG /MD  /O1 /Ob1 /Oi /GS- ${CL_INST_SET}")    ## C++    SET(CMAKE_CXX_FLAGS_DEBUG "/MP${mxcpu} ${BUILD_CXX_FLAGS_DEBUG}"        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    SET(CMAKE_CXX_FLAGS_RELEASE "/MP${mxcpu} ${BUILD_CXX_FLAGS_RELEASE}"        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "/MP${mxcpu} ${BUILD_CXX_FLAGS_RELWITHDEBINFO}"        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    SET(CMAKE_CXX_FLAGS_MINSIZEREL "/MP${mxcpu} ${BUILD_CXX_FLAGS_MINSIZEREL}"        CACHE STRING "Can't change here -- see BUILD_CXX..." FORCE)    ## C    SET(CMAKE_C_FLAGS_DEBUG "/MP${mxcpu} ${BUILD_C_FLAGS_DEBUG}"        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)    SET(CMAKE_C_FLAGS_RELEASE "/MP${mxcpu} ${BUILD_C_FLAGS_RELEASE}"        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)    SET(CMAKE_C_FLAGS_RELWITHDEBINFO "/MP${mxcpu} ${BUILD_C_FLAGS_RELWITHDEBINFO}"        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)    SET(CMAKE_C_FLAGS_MINSIZEREL "/MP${mxcpu} ${BUILD_C_FLAGS_MINSIZEREL}"        CACHE STRING "Can't change here -- see BUILD_C_..." FORCE)ENDIF()# The source is organized into subdirectories, but we handle them all from# this CMakeLists file rather than letting CMake visit them as SUBDIRS.set(MOLMODEL_SOURCE_SUBDIRS .)# Collect up information about the version of the molmodel library we're building# and make it available to the code so it can be built into the binaries.# Get the subversion revision number if we can# It's possible that WIN32 installs use svnversion through cygwin# so we'll try for both svnversion.exe and svnversion. Note that# this will result in warnings if all you have is Tortoise without# Cygwin, and your "about" string will say "unknown" rather than# providing the SVN version of the source.# If there is an actual reason for the SVNVERSION vs. SVNVERSION_EXE# nonsense that was here before, come talk to me.  --Chris Bruns# 1) CMake already understands that Windows executables have ".exe" at the end.# 2) Providing a PATHS argument to find_program is *NOT* hard coding a single path.# Please read the CMake documentation for more details.find_program(SVNVERSION_EXECUTABLE svnversion PATHS "C:/cygwin/bin")if(SVNVERSION_EXECUTABLE)    exec_program(${SVNVERSION_EXECUTABLE}              # Works better on Windows to set working directory rather than              # passing argument to svnversion              ${CMAKE_SOURCE_DIR} # cwd for run              OUTPUT_VARIABLE OUT)    set(MOLMODEL_SVN_REVISION "${OUT}" CACHE STRING "Molmodel svn revision number" FORCE)else(SVNVERSION_EXECUTABLE)    message(STATUS          "Could not find 'svnversion' executable; 'about' will be wrong. (Cygwin provides one on Windows.)"        )    set(MOLMODEL_SVN_REVISION "unknown" CACHE STRING "Molmodel svn revision number")endif(SVNVERSION_EXECUTABLE)mark_as_advanced(MOLMODEL_SVN_REVISION)# Remove colon from build version, for easier placement in directory namesSTRING(REPLACE ":" "_" MOLMODEL_SVN_REVISION ${MOLMODEL_SVN_REVISION})ADD_DEFINITIONS(-DSimTK_MOLMODEL_LIBRARY_NAME=${MOLMODEL_LIBRARY_NAME}                -DSimTK_MOLMODEL_MAJOR_VERSION=${MOLMODEL_MAJOR_VERSION}                -DSimTK_MOLMODEL_MINOR_VERSION=${MOLMODEL_MINOR_VERSION}		-DSimTK_MOLMODEL_PATCH_VERSION=${MOLMODEL_PATCH_VERSION})# CMake quotes automatically when building Visual Studio projects but we need# to add them ourselves for Linux or Cygwin. Two cases to avoid duplicate quotes# in Visual Studio which end up in the binary.IF (${CMAKE_GENERATOR} MATCHES "Visual Studio")   SET(NEED_QUOTES FALSE)ELSE (${CMAKE_GENERATOR} MATCHES "Visual Studio")   SET(NEED_QUOTES TRUE)ENDIF (${CMAKE_GENERATOR} MATCHES "Visual Studio")##TODO: doesn't work without quotes in nightly buildset(NEED_QUOTES TRUE)IF(NEED_QUOTES)   ADD_DEFINITIONS(-DSimTK_MOLMODEL_SVN_REVISION="${MOLMODEL_SVN_REVISION}"                   -DSimTK_MOLMODEL_COPYRIGHT_YEARS="${MOLMODEL_COPYRIGHT_YEARS}"                   -DSimTK_MOLMODEL_AUTHORS="${MOLMODEL_AUTHORS}")ELSE(NEED_QUOTES)   ADD_DEFINITIONS(-DSimTK_MOLMODEL_SVN_REVISION=${MOLMODEL_SVN_REVISION}                   -DSimTK_MOLMODEL_COPYRIGHT_YEARS=${MOLMODEL_COPYRIGHT_YEARS}                   -DSimTK_MOLMODEL_AUTHORS=${MOLMODEL_AUTHORS})ENDIF(NEED_QUOTES)# -DSimTK_MOLMODEL_TYPE has to be defined in the target subdirectories.# -Dmolmodel_EXPORTS defined automatically when Windows DLL build is being done.set(SHARED_TARGET ${MOLMODEL_LIBRARY_NAME})set(STATIC_TARGET ${MOLMODEL_LIBRARY_NAME}_static)set(SHARED_TARGET_VN ${MOLMODEL_LIBRARY_NAME}${VN})set(STATIC_TARGET_VN ${MOLMODEL_LIBRARY_NAME}${VN}_static)# Ensure that debug libraries have "_d" appended to their names.# CMake gets this right on Windows automatically with this definition.IF (${CMAKE_GENERATOR} MATCHES "Visual Studio")    SET(CMAKE_DEBUG_POSTFIX "_d" CACHE INTERNAL "" FORCE)ENDIF (${CMAKE_GENERATOR} MATCHES "Visual Studio")# But on Unix or Cygwin we have to add the suffix manuallyIF (UNIX AND CMAKE_BUILD_TYPE MATCHES Debug)    SET(SHARED_TARGET ${SHARED_TARGET}_d)    SET(STATIC_TARGET ${STATIC_TARGET}_d)    SET(SHARED_TARGET_VN ${SHARED_TARGET_VN}_d)    SET(STATIC_TARGET_VN ${STATIC_TARGET_VN}_d)ENDIF (UNIX AND CMAKE_BUILD_TYPE MATCHES Debug)## Test against the unversioned libraries if they are being built;## otherwise against the versioned libraries.IF(BUILD_UNVERSIONED_LIBRARIES)	SET(TEST_SHARED_TARGET ${SHARED_TARGET})	SET(TEST_STATIC_TARGET ${STATIC_TARGET})ELSE(BUILD_UNVERSIONED_LIBRARIES)	SET(TEST_SHARED_TARGET ${SHARED_TARGET_VN})	SET(TEST_STATIC_TARGET ${STATIC_TARGET_VN})ENDIF(BUILD_UNVERSIONED_LIBRARIES)IF(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")    SET(ADDITIONAL_LINK_LIBRARIES)ELSE(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")    ## Assume Microsoft Visual Studio	## ws2_32 is for socket calls in VMD connection    SET(ADDITIONAL_LINK_LIBRARIES ws2_32)ENDIF(${CMAKE_C_COMPILER} MATCHES "cc" OR ${CMAKE_C_COMPILER} MATCHES "clang")SET ( USE_GEMMI  TRUE  CACHE BOOL "Should the Gemmi library be linked to the build?" )SET ( GEMMI_PATH ""    CACHE PATH "Where is the Gemmi library installed?" )IF ( USE_GEMMI )	ADD_DEFINITIONS     ( -DGEMMI_USAGE )	INCLUDE_DIRECTORIES ( ${GEMMI_PATH} )	SET ( ADDITIONAL_LINK_LIBRARIES ${ADDITIONAL_LINK_LIBRARIES} "-lz" )ENDIF ( USE_GEMMI )# These are all the places to search for header files which are# to be part of the API.set(API_INCLUDE_DIRS) # start emptyFOREACH(subdir ${MOLMODEL_SOURCE_SUBDIRS})    # append    SET(API_INCLUDE_DIRS ${API_INCLUDE_DIRS}                         ${subdir}/include                          ${subdir}/include/molmodel                          ${subdir}/include/molmodel/internal)ENDFOREACH(subdir)# We'll need both *relative* path names, starting with their API_INCLUDE_DIRS,# and absolute pathnames.set(API_REL_INCLUDE_FILES)   # start these out emptyset(API_ABS_INCLUDE_FILES)FOREACH(dir ${API_INCLUDE_DIRS})    FILE(GLOB fullpaths ${dir}/*.h)	# returns full pathnames    SET(API_ABS_INCLUDE_FILES ${API_ABS_INCLUDE_FILES} ${fullpaths})    FOREACH(pathname ${fullpaths})        GET_FILENAME_COMPONENT(filename ${pathname} NAME)        SET(API_REL_INCLUDE_FILES ${API_REL_INCLUDE_FILES} ${dir}/${filename})    ENDFOREACH(pathname)ENDFOREACH(dir)# collect up source filesset(SOURCE_FILES) # emptyset(SOURCE_INCLUDE_FILES)FOREACH(subdir ${MOLMODEL_SOURCE_SUBDIRS})    FILE(GLOB src_files  ${subdir}/src/*.cpp ${subdir}/src/*.c                         ${subdir}/src/*/*.cpp ${subdir}/src/*/*.c)    FILE(GLOB incl_files ${subdir}/src/*.h ${subdir}/src/*/*.h )    SET(SOURCE_FILES         ${SOURCE_FILES}         ${src_files})   #append    SET(SOURCE_INCLUDE_FILES ${SOURCE_INCLUDE_FILES} ${incl_files})    ## Make sure we find these locally before looking in    ## SimTK/include if Molmodel was previously installed there.    INCLUDE_DIRECTORIES(BEFORE ${PROJECT_SOURCE_DIR}/${subdir}/include)ENDFOREACH(subdir)INCLUDE_DIRECTORIES(BEFORE ${PROJECT_SOURCE_DIR}/src)## Allow automated build and dashboard.#INCLUDE (Dart)IF (BUILD_TESTING)    #IF (UNIX AND NOT CYGWIN AND NOT APPLE)    #  IF (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE MATCHES Debug)    #    ADD_DEFINITIONS(-fprofile-arcs -ftest-coverage)    #    LINK_LIBRARIES(gcov)    #  ENDIF (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE MATCHES Debug)    #ENDIF (UNIX AND NOT CYGWIN AND NOT APPLE)    #    # Testing    #    ENABLE_TESTING()ENDIF (BUILD_TESTING)INCLUDE(ApiDoxygen.cmake)# libraries are installed from their subdirectories; headers here# install headersFILE(GLOB CORE_HEADERS     include/*.h                  */include/*.h)FILE(GLOB TOP_HEADERS      include/molmodel/*.h          */include/molmodel/*.h)FILE(GLOB INTERNAL_HEADERS include/molmodel/internal/*.h */include/molmodel/internal/*.h)INSTALL_FILES(/include/                 FILES ${CORE_HEADERS})INSTALL_FILES(/include/molmodel/         FILES ${TOP_HEADERS})INSTALL_FILES(/include/molmodel/internal FILES ${INTERNAL_HEADERS})# Install documents.FILE(GLOB TOPLEVEL_DOCS doc/*.pdf doc/*.txt)INSTALL(FILES ${TOPLEVEL_DOCS} DESTINATION doc)# These are at the end because we want them processed after# all the various variables have been set above.IF(BUILD_STATIC_LIBRARIES)        ADD_SUBDIRECTORY( staticTarget )ENDIF()ADD_SUBDIRECTORY( sharedTarget )IF (MOLMODEL_USE_OpenMM)    ADD_SUBDIRECTORY( OpenMMPlugin )ENDIF (MOLMODEL_USE_OpenMM)IF( BUILD_EXAMPLES )  ADD_SUBDIRECTORY( examples )ENDIF()IF( BUILD_TESTING )  ADD_SUBDIRECTORY( tests )ENDIF()

--- a/include/molmodel/internal/Compound.h
+++ b/include/molmodel/internal/Compound.h
@@ -857,6 +857,7 @@ public:
          const State& state, ///< simbody state representing the current configuration of the molecule
          gemmi::Model* gemmiModel,  ///< Gemmi library model object pointer to which the molmodel structure information will be copied into.
          bool isPolymer, ///< Is this compound a polymer?
+         int decimal_places = 8, ///< Number of decimal places to which the co-ordinates are to be rounded to.
          const Transform& transform = Transform() ///< optional change to location and orientation of molecule
          ) const;
 #endif

--- a/include/molmodel/internal/Compound.h
+++ b/include/molmodel/internal/Compound.h
@@ -44,12 +44,12 @@
 
 #include <iosfwd> // declare ostream without all the definitions
 
-#ifdef MMDB2_LIB_USAGE
-  #include <mmdb2/mmdb_manager.h>
-#endif
-
-#ifdef CPP4_MAPS_USAGE
-  #include <mmdb2/mmdb_manager.h>
+#ifdef GEMMI_USAGE
+    #include <gemmi/mmread.hpp>
+    #include <gemmi/it92.hpp>
+    #include <gemmi/cif.hpp>
+    #include <gemmi/model.hpp>
+    #include <gemmi/cifdoc.hpp>
 #endif
 
 namespace SimTK {
@@ -847,21 +847,16 @@ public:
       * mmCIF file to be created.
       */
     
-#ifdef MMDB2_LIB_USAGE
-     void writeEntityPolySeqLoop(
-         const State& state, ///< simbody state representing the current configuration of the molecule
-         mmdb::io::File *cifFile,  ///< MMDB2 File pointer - to this file object will the loop be written into.
-         int compoundNumber ///< Compound number.
-         ) const;
-
-     /** \brief Create the MMDB2 object structure for mmCIF writing..
+#ifdef GEMMI_USAGE
+     /** \brief Create the Gemmi Structure object structure for mmCIF writing..
       *
-      * Starting with the first atom's serial number as one(1), this function will fill in the MMDB2 objects structure with the structural
+      * Starting with the first atom's serial number as one(1), this function will fill in the Gemmi structure objects structure with the structural
       * data so that these can be written into a mmCIF file.
       */
      void buildCif(
          const State& state, ///< simbody state representing the current configuration of the molecule
-         mmdb::Model* mmdb2Model,  ///< MMDB2 library model object pointer to which the MMDB2 object structure will be build into.
+         gemmi::Model* gemmiModel,  ///< Gemmi library model object pointer to which the molmodel structure information will be copied into.
+         bool isPolymer, ///< Is this compound a polymer?
          const Transform& transform = Transform() ///< optional change to location and orientation of molecule
          ) const;
 #endif

--- a/src/Compound.cpp
+++ b/src/Compound.cpp
@@ -1005,7 +1005,7 @@ std::ostream& CompoundRep::writeDefaultPdb(std::ostream& os, int& nextSerialNumb
 }
 
 #ifdef GEMMI_USAGE
-void CompoundRep::buildCif( const State& state, gemmi::Model* gemmiModel, bool isPolymer, const Transform& transform = Transform() ) const
+void CompoundRep::buildCif( const State& state, gemmi::Model* gemmiModel, bool isPolymer, int decimal_places = 8, const Transform& transform = Transform() ) const
 {
     //================================================ Initialise local variables
     PdbChain chain                                    ( state, getOwnerHandle(), transform );
@@ -1052,9 +1052,9 @@ void CompoundRep::buildCif( const State& state, gemmi::Model* gemmiModel, bool i
             gemmiAtom.element                         = gemmi::Element ( (*atomI).element.getSymbol() );
             const PdbAtomLocation& location           = (*atomI).getPdbAtomLocation();
             Vec3 modCoords                            = transform * location.getCoordinates();
-            gemmiAtom.pos                             = gemmi::Position ( static_cast<double> ( modCoords[0] * 10.0 ),
-                                                                          static_cast<double> ( modCoords[1] * 10.0 ),
-                                                                          static_cast<double> ( modCoords[2] * 10.0 ) );
+            gemmiAtom.pos                             = gemmi::Position ( static_cast<double> ( std::ceil ( (modCoords[0] * 10.0) * std::pow ( 10.0, decimal_places ) ) / std::pow ( 10.0, decimal_places ) ),
+                                                                          static_cast<double> ( std::ceil ( (modCoords[1] * 10.0) * std::pow ( 10.0, decimal_places ) ) / std::pow ( 10.0, decimal_places ) ),
+                                                                          static_cast<double> ( std::ceil ( (modCoords[2] * 10.0) * std::pow ( 10.0, decimal_places ) ) / std::pow ( 10.0, decimal_places ) ) );
             gemmiAtom.occ                             = static_cast<double> ( location.getOccupancy() );
             gemmiAtom.b_iso                           = static_cast<double> ( location.getTemperatureFactor() );
             gemmiAtom.serial                          = nextAtomSerialNumber;
@@ -2025,9 +2025,9 @@ void Compound::writeDefaultPdb(const char* outFileName, const Transform& transfo
 }
 
 #ifdef GEMMI_USAGE
-void Compound::buildCif( const State& state, gemmi::Model* gemmiModel, bool isPolymer, const Transform& transform ) const
+void Compound::buildCif( const State& state, gemmi::Model* gemmiModel, bool isPolymer, int decimal_places, const Transform& transform ) const
 {
-    getImpl().buildCif ( state, gemmiModel, isPolymer, transform );
+    getImpl().buildCif ( state, gemmiModel, isPolymer, decimal_places, transform );
     return ;
 }
 #endif

--- a/src/Compound.cpp
+++ b/src/Compound.cpp
@@ -1004,143 +1004,74 @@ std::ostream& CompoundRep::writeDefaultPdb(std::ostream& os, int& nextSerialNumb
     return os;
 }
 
-#ifdef MMDB2_LIB_USAGE
-void CompoundRep::writeEntityPolySeqLoop( const State& state, mmdb::io::File *cifFile, int compoundNumber ) const
+#ifdef GEMMI_USAGE
+void CompoundRep::buildCif( const State& state, gemmi::Model* gemmiModel, bool isPolymer, const Transform& transform = Transform() ) const
 {
-    //================================================ Prepare the basic sequence loop ( _entity_poly_seq )
-    mmdb::mmcif::Loop loop;
-    loop.SetCategoryName                              ( "_entity_poly_seq" );
-    std::string hlpNam;
-
-    //================================================ Create loop structure
-    loop.AddLoopTag                                   ( "entity_id"    );
-    loop.AddLoopTag                                   ( "num"  );
-    loop.AddLoopTag                                   ( "mon_id" );
-    loop.AddLoopTag                                   ( "hetero" );
-
-    //================================================ Fill loop with data
-    PdbChain chain                                    ( state, getOwnerHandle() );
-    decltype(chain)::Residues::const_iterator residueI;
-    int residueNumber                                 = 1;
-    for ( residueI = chain.residues.begin(); residueI != chain.residues.end(); ++residueI)
-    {
-        loop.AddInteger                               ( compoundNumber );
-        loop.AddInteger                               ( residueNumber );
-
-        hlpNam                                        = std::string ( (*residueI).getName() );
-        hlpNam                                        = std::regex_replace ( hlpNam, std::regex ( "\\s+$" ), std::string ( "" ) );
-
-
-        loop.AddString                                ( hlpNam.c_str() );
-        loop.AddString                                ( std::string ( "n" ).c_str() );
-        ++residueNumber;
-    }
-
-    //================================================ Write loop into the file
-    loop.WriteMMCIF                                   ( *cifFile );
-
-    //================================================ Done
-    return ;
-}
-
-void CompoundRep::buildCif( const State& state, mmdb::Model* mmdb2Model, const Transform& transform = Transform() ) const
-{
-    //================================================ Get compound chain
+    //================================================ Initialise local variables
     PdbChain chain                                    ( state, getOwnerHandle(), transform );
-
-    //================================================ Create MMDB2 chain object
-    mmdb::Chain *mmdb2Chain                           = new mmdb::Chain ( mmdb2Model, chain.getChainId() );
-
-    //================================================ Iterate over all residues
+    gemmi::Chain gemmiChain                           ( chain.getChainId() );
     int nextAtomSerialNumber                          = 1;
     int nextResidueSerialNumber                       = 1;
     size_t pos;
-    std::string nameHlp;
+    
+    //================================================ Copy information to chain
+    gemmiChain.name                                   = chain.getChainId();
+    
+    //================================================ For each molmodel residue in chain
     decltype(chain)::Residues::const_iterator residueI;
     for ( residueI = chain.residues.begin(); residueI != chain.residues.end(); ++residueI)
     {
-        //============================================ Create the MMDB2 residue object
-        mmdb::Residue *mmdb2Residue                   = new mmdb::Residue ( mmdb2Chain );
-
-        //============================================ And fill it with the information
-        strncpy                                       ( mmdb2Residue->insCode, "         ", 10 );
-        mmdb2Residue->insCode[0]                      = (*residueI).getResidueId().insertionCode;
-        mmdb2Residue->insCode[1]                      = '\0';
-
-        mmdb2Residue->seqNum                          = (*residueI).getResidueId().residueNumber;
-        mmdb2Residue->label_seq_id                    = nextResidueSerialNumber;
-
-        strncpy                                       ( mmdb2Residue->name, "                   ", 20 );
-        nameHlp                                       = std::string ( (*residueI).getName() );
-        strncpy                                       ( mmdb2Residue->name, nameHlp.c_str(), std::min( static_cast<int> ( nameHlp.length() ), 4 ) );
-        nameHlp                                       = std::regex_replace ( nameHlp, std::regex ( "\\s+$" ), std::string ( "" ) );
-        if ( nameHlp.length() < 3 ) { mmdb2Residue->name[nameHlp.length()] = '\0'; }
-
-        strncpy                                       ( mmdb2Residue->label_comp_id, "                   ", 20 );
-        nameHlp                                       = std::string ( (*residueI).getName() );
-        strncpy                                       ( mmdb2Residue->label_comp_id, nameHlp.c_str(), std::min( static_cast<int> ( nameHlp.length() ), 4 ) );
-        nameHlp                                       = std::regex_replace ( nameHlp, std::regex ( "\\s+$" ), std::string ( "" ) );
-        if ( nameHlp.length() < 3 ) { mmdb2Residue->label_comp_id[nameHlp.length()] = '\0'; }
-
-        strncpy                                       ( mmdb2Residue->label_asym_id, "         ", 10 );
-        strncpy                                       ( mmdb2Residue->label_asym_id, chain.getChainId().c_str(), std::min( 10, chain.getChainId().length() ) );
-        if ( chain.getChainId().length() < 9 ) { mmdb2Residue->label_asym_id[chain.getChainId().length()] = '\0'; }
-
-        //============================================ Iterate over all atoms for the residue
+        //============================================ Create new Gemmi residue
+        gemmi::Residue gemmiRes;
+        
+        //============================================ Copy information to residue
+        gemmiRes.name                                 = std::string ( (*residueI).getName() );
+        gemmiRes.name.resize                          ( 3 );
+        if ( gemmiRes.name[3] == ' ' )                { gemmiRes.name.erase ( 2, 3 ); }
+        if ( gemmiRes.name[2] == ' ' )                { gemmiRes.name.erase ( 1, 2 ); }
+        
+        gemmiRes.seqid                                = gemmi::SeqId ( (*residueI).getResidueId().residueNumber, (*residueI).getResidueId().insertionCode );
+        gemmiRes.label_seq                            = nextResidueSerialNumber;
+        if ( isPolymer ) { gemmiRes.entity_type       = gemmi::EntityType::Polymer; }
+        else             { gemmiRes.entity_type       = gemmi::EntityType::Unknown; }
+        gemmiRes.het_flag                             = '\0';
+        
+        //============================================ For each molmodel atom
         SimTK::PdbResidue::Atoms::const_iterator atomI;
         for ( atomI = (*residueI).atoms.begin(); atomI != (*residueI).atoms.end(); ++atomI)
         {
-            //======================================== Create the MMDB2 Atom object
-            mmdb::Atom *mmdb2Atom                     = new mmdb::Atom ( mmdb2Residue );
-
-            //======================================== And fill it with the information
-            mmdb2Atom->serNum                         = nextAtomSerialNumber;                                      // Serial number
-
-            strncpy                                   ( mmdb2Atom->name, "                   ", 20 );
-            nameHlp                                   = std::string ( (*atomI).getName() );
-            while ( ( pos = nameHlp.find ( "*" ) ) != std::string::npos ) { nameHlp.replace ( pos, 1, "'" ); }
-            strncpy                                   ( mmdb2Atom->name, nameHlp.c_str(), std::min( 20, static_cast<int> ( nameHlp.length() ) ) ); // Atom name
-            if ( nameHlp.length() < 19 ) { mmdb2Atom->name[nameHlp.length()] = '\0'; }
-
-
-            strncpy                                   ( mmdb2Atom->altLoc, "                   ", 20 );
-            mmdb2Atom->altLoc[0]                      = ' ';                                                       // Alternative location - currently not applicable
-
-            const PdbAtomLocation& location           = (*atomI).getPdbAtomLocation();                             // Writing out the coords as follows:
+            //======================================== Create new Gemmi atom
+            gemmi::Atom gemmiAtom;
+            
+            //======================================== Copy information to atom
+            gemmiAtom.name                            = std::string ( (*atomI).getName() );
+            while ( ( pos = gemmiAtom.name.find ( "*" ) ) != std::string::npos ) { gemmiAtom.name.replace ( pos, 1, "'" ); }
+            gemmiAtom.name.erase                      ( std::remove ( gemmiAtom.name.begin(), gemmiAtom.name.end(), ' ' ), gemmiAtom.name.end() );
+            gemmiAtom.altloc                          = '\0';
+            gemmiAtom.charge                          = 0;
+            gemmiAtom.element                         = gemmi::Element ( (*atomI).element.getSymbol() );
+            const PdbAtomLocation& location           = (*atomI).getPdbAtomLocation();
             Vec3 modCoords                            = transform * location.getCoordinates();
-            mmdb2Atom->SetCoordinates                 ( static_cast<double> ( modCoords[0] * 10.0 ),               // X (the time ten is to convert from nm to A)
-                                                        static_cast<double> ( modCoords[1] * 10.0 ),               // Y (the time ten is to convert from nm to A)
-                                                        static_cast<double> ( modCoords[2] * 10.0 ),               // Z (the time ten is to convert from nm to A)
-                                                        static_cast<double> ( location.getOccupancy() ),           // Occupancy
-                                                        static_cast<double> ( location.getTemperatureFactor() ) ); // B-factor
-
-            std::string elem                          = (*atomI).element.getSymbol();                              // Element symbol with conversion
-            std::transform                            ( elem.begin(), elem.end(), elem.begin(), ( int(*)(int) ) toupper );
-            strncpy                                   ( mmdb2Atom->element, elem.c_str(), std::min( 10, static_cast<int> ( elem.length() ) ) );
-
-            strncpy                                   ( mmdb2Atom->label_atom_id, "                   ", 20 );
-            nameHlp                                   = std::string ( (*atomI).getName() );
-            while ( ( pos = nameHlp.find ( "*" ) ) != std::string::npos ) { nameHlp.replace ( pos, 1, "'" ); }
-            strncpy                                   ( mmdb2Atom->label_atom_id, nameHlp.c_str(), std::min( 20, static_cast<int> ( nameHlp.length() ) ) ); // Author atom name
-            if ( nameHlp.length() < 19 ) { mmdb2Atom->label_atom_id[nameHlp.length()] = '\0'; }
-
-            //======================================== Update the atom serial number
-            ++nextAtomSerialNumber;
-
-            //======================================== Add atom to residue
-            mmdb2Residue->AddAtom                     ( mmdb2Atom );
+            gemmiAtom.pos                             = gemmi::Position ( static_cast<double> ( modCoords[0] * 10.0 ),
+                                                                          static_cast<double> ( modCoords[1] * 10.0 ),
+                                                                          static_cast<double> ( modCoords[2] * 10.0 ) );
+            gemmiAtom.occ                             = static_cast<double> ( location.getOccupancy() );
+            gemmiAtom.b_iso                           = static_cast<double> ( location.getTemperatureFactor() );
+            gemmiAtom.serial                          = nextAtomSerialNumber;
+            nextAtomSerialNumber++;
+            
+            //======================================== Save atom to residue
+            gemmiRes.atoms.push_back                  ( gemmiAtom );
         }
-
-        //============================================ Update the residue serial number
-        ++nextResidueSerialNumber;
-
-        //============================================ Add residue to chain
-        mmdb2Chain->AddResidue                        ( mmdb2Residue );
+        
+        //============================================ Save residue to chain
+        gemmiChain.residues.push_back                 ( gemmiRes );
+        nextResidueSerialNumber++;
     }
-
-    //================================================ Add chain to the model
-    mmdb2Model->AddChain                              ( mmdb2Chain );
-
+    
+    //================================================ Save chain to model
+    gemmiModel->chains.push_back                      ( gemmiChain );
+    
     //================================================ Done
     return;
 }
@@ -2093,16 +2024,10 @@ void Compound::writeDefaultPdb(const char* outFileName, const Transform& transfo
     os.close();
 }
 
-#ifdef MMDB2_LIB_USAGE
-void Compound::writeEntityPolySeqLoop( const State& state, mmdb::io::File *cifFile, int compoundNumber ) const
+#ifdef GEMMI_USAGE
+void Compound::buildCif( const State& state, gemmi::Model* gemmiModel, bool isPolymer, const Transform& transform ) const
 {
-    getImpl().writeEntityPolySeqLoop ( state, cifFile, compoundNumber );
-    return ;
-}
-
-void Compound::buildCif( const State& state, mmdb::Model* mmdb2Model, const Transform& transform ) const
-{
-    getImpl().buildCif ( state, mmdb2Model, transform );
+    getImpl().buildCif ( state, gemmiModel, isPolymer, transform );
     return ;
 }
 #endif

--- a/src/CompoundRep.h
+++ b/src/CompoundRep.h
@@ -1758,24 +1758,16 @@ public:
     //    const Transform& transform
     //    ) const;
 
-#ifdef MMDB2_LIB_USAGE
+#ifdef GEMMI_USAGE
   /**
-   * \brief Write the entity_poly_seq loop into the MMDB2 Data object.
-   */
-  void writeEntityPolySeqLoop(
-      const State& state, ///< simbody state representing the current configuration of the molecule
-      mmdb::io::File *cifFile,  ///< MMDB2 File pointer - to this file object will the loop be written into.
-      int compoundNumber ///< Compound number.
-      ) const;
-
-  /**
-   * \brief Create the MMDB2 object structure for mmCIF writing..
+   * \brief Create the gemmi Structure object structure for mmCIF writing..
    *
    * Starting with the first atom's serial number as one(1).
    */
   void buildCif(
       const State& state, ///< simbody state representing the current configuration of the molecule
-      mmdb::Model* mmdb2Model,  ///< MMDB2 library model object pointer to which the MMDB2 object structure will be build into.
+      gemmi::Model* gemmiModel,  ///< Gemmi library Model object pointer to which the molmodel object structure will be saveds into.
+      bool isPolymer, ///< Is this compound a polymer?
       const Transform& transform ///< optional change to location and orientation of molecule
       ) const;
 #endif

--- a/src/CompoundRep.h
+++ b/src/CompoundRep.h
@@ -1768,6 +1768,7 @@ public:
       const State& state, ///< simbody state representing the current configuration of the molecule
       gemmi::Model* gemmiModel,  ///< Gemmi library Model object pointer to which the molmodel object structure will be saveds into.
       bool isPolymer, ///< Is this compound a polymer?
+      int decimal_places, ///< Number of decimal place to which the co-ordinates to to be rounded to.
       const Transform& transform ///< optional change to location and orientation of molecule
       ) const;
 #endif

--- a/src/PDBReader.cpp
+++ b/src/PDBReader.cpp
@@ -61,7 +61,8 @@ public:
         {
             mol_DbRead("mol", filename.c_str(), MOL_DB_PDB, &model );
         }
-        else if ( filename.substr ( filename.length() - 4, filename.length() - 1) == ".cif" )
+        else if ( ( filename.substr ( filename.length() - 4, filename.length() - 1) == ".cif" ) ||
+                  ( filename.substr ( filename.length() - 7, filename.length() - 1) == ".cif.gz" ) )
         {
 #ifdef MMDB2_LIB_USAGE
             //======================================== Open file
@@ -330,13 +331,13 @@ public:
             //======================================== Clean up
             delete mfile;
 #else
-            std::cerr << "ERROR: The suplied file has the mmCIF format, but Molmodel was not compiled with the MMDB2 library, which is required for the mmCIF support. Please re-run the Molmodel cmake command with the -DADD_MMDB2_LIBRARY=TRUE option (and then alse re-run the make install command). Terminating..." << std::endl;
+            std::cerr << "ERROR: The suplied file has the mmCIF format, but Molmodel was not compiled with the Gemmi library, which is required for the mmCIF support. Please re-run the Molmodel cmake command with the -DUSE_GEMMI=TRUE -DGEMMI_PATH=/path/to/gemmi/include options (and then alse re-run the make install command). Terminating..." << std::endl;
             exit                                      ( -1 );
 #endif
         }
         else
         {
-            std::cerr << "Failed to detect the extension of the input file " << filename << ". The supported extensions are: \'.pdb\' and \'.cif\'. Terminating now..." << std::endl;
+            std::cerr << "Failed to detect the extension of the input file " << filename << ". The supported extensions are: \'.pdb\' and \'.cif\' (or \'.cif.gz\'). Terminating now..." << std::endl;
             exit                                      ( -1 );
         }
 

--- a/src/PDBReader.cpp
+++ b/src/PDBReader.cpp
@@ -40,10 +40,10 @@
 #include <vector>
 #include <algorithm>
 
-#ifdef MMDB2_LIB_USAGE
-  #include <mmdb2/mmdb_manager.h>
+#ifdef GEMMI_USAGE
+    //================================================ Include Gemmi headers
+    #include <gemmi/gz.hpp>
 #endif
-
 
 using namespace SimTK;
 using std::map;
@@ -64,274 +64,99 @@ public:
         else if ( ( filename.substr ( filename.length() - 4, filename.length() - 1) == ".cif" ) ||
                   ( filename.substr ( filename.length() - 7, filename.length() - 1) == ".cif.gz" ) )
         {
-#ifdef MMDB2_LIB_USAGE
-            //======================================== Open file
-            mmdb::CoorManager *mfile                  = new mmdb::CoorManager ( );
+#ifdef GEMMI_USAGE
+            //======================================== Read in the file into Gemmi document
+            gemmi::cif::Document gemmiDoc             = gemmi::cif::read ( gemmi::MaybeGzipped ( filename ) );
             
-            //======================================== Check that the file was opened correctly
-            if ( mfile->ReadCoorFile ( filename.c_str() ) )
+            //======================================== Check the number of blocks
+            if ( gemmiDoc.blocks.size() < 1 )
             {
-                std::cout << "MMDB2 Failed to open the file " << filename << ". Terminating now..." << std::endl;
-                exit                                  ( -1 );
+                std::cerr << "!!! Error !!! The file " << filename << " contains 0 blocks. Nothing the be read." << std::endl;
+                exit                                  ( EXIT_FAILURE );
             }
-        
-            //======================================== Initialise the molmodel model
-            mol_MolModelCreate                        ( "mol", &model );
-            
-            //======================================== Initialise MMDB crawl
-            int noModels                              = 0;
-            int noChains                              = 0;
-            int noResidues                            = 0;
-            int noAtoms                               = 0;
-            mmdb::Model **mmdb2Model;
-            mmdb::Chain **mmdb2Chain;
-            mmdb::Residue **mmdb2Residue;
-            mmdb::Atom **mmdb2Atom;
-            
-            //======================================== Find all models in the PDB file
-            mfile->GetModelTable                      ( mmdb2Model, noModels );
-            
-            //======================================== Check that at least one model was found
-            if ( noModels < 1 )
+            else if ( gemmiDoc.blocks.size() > 1 )
             {
-                std::cerr << "MMDB2 found no models the file " << filename << ". Terminating now..." << std::endl;
-                exit                                  ( -1 );
+                std::cerr << "!!! Warning !!! The file " << filename << " contains multiple blocks. Molmodel will use the first block named " << gemmiDoc.blocks.at(0).name << " and ignore the rest." << std::endl;
             }
-            
-            //======================================== If there are multiple models, just the first one will be used. This may needs some tweaking in the future
-            if ( noModels < 1 )
-            {
-                std::cout << "WARNING: MMDB2 found multiple models (" << noModels << ") the file " << filename << ". Only the first model will be used." << std::endl;
-            }
-            
-            //======================================== Check the first model is readable
-            if ( mmdb2Model[0] )
-            {
-                //==================================== Deal with secondary structure's (alpha-helices first)
-                int noHelices                         = mmdb2Model[0]->GetNumberOfHelices ( );
-                
-                for ( int hNo = 0; hNo < noHelices; hNo++ )
-                {
-                    //================================ Initialise variables
-                    MolStructure *hStruc;
-                    MolHelix helix;
-                    mmdb::Helix *mmdb2Helix           = mmdb2Model[0]->GetHelix ( hNo+1 );
-                    
-                    //================================ Copy relevant information to molmodel structures
-                    helix.num                         = mmdb2Helix->serNum;
-                    mol_DbRecordStrGet                ( mmdb2Helix->helixID,     1, 3, helix.id );
-                    mol_DbRecordStrGet                ( mmdb2Helix->initResName, 1, 3, helix.init_res_name );
-                    helix.init_chain_id               = mmdb2Helix->initChainID[0];
-                    helix.init_seq_num                = mmdb2Helix->initSeqNum;
-                    mol_DbRecordStrGet                ( mmdb2Helix->endResName,  1, 3, helix.term_res_name );
-                    helix.term_chain_id               = mmdb2Helix->endChainID[0];
-                    helix.term_seq_num                = mmdb2Helix->endSeqNum;
-                    helix.helixClass                  = mmdb2Helix->helixClass;
-                    helix.length                      = mmdb2Helix->length;
-                    
-                    //================================ Save the read helix to the molmodel model
-                    mol_MolModelCurrStrucGet          ( model, &hStruc ); // Copies model->curr_struc to hStruc
-                    
-                    MolHelix *hlist;
-                    int num                           = hStruc->secondary.helix.num;
-                    int size                          = hStruc->secondary.helix.size;
-                    hlist                             = hStruc->secondary.helix.list;
-                    if (num == (size - 1))
-                    {
-                        size                         += 1000;
-                        mem_Realloc                   ( hlist, size, hStruc->model, MolHelix* );
-                        hStruc->secondary.helix.size  = size;
-                        hStruc->secondary.helix.list  = hlist;
-                    }
-                    memcpy                            ( hlist+num, &helix, sizeof(MolHelix) );
-                    num                              += 1;
-                    hStruc->secondary.helix.num       = num;
-                }
-                
-                //==================================== Deal with secondary structure's (beta-sheets now)
-                int noSheets                          = mmdb2Model[0]->GetNumberOfSheets ( );
-                
-                for ( int sNo = 0; sNo < noSheets; sNo++ )
-                {
-                    //================================ Initialise variables
-                    mmdb::Sheet *mmdb2Sheet           = mmdb2Model[0]->GetSheet ( sNo+1 );
-                    
-                    int noStrands                     = mmdb2Sheet->nStrands;
-                    for ( int stNo = 0; stNo < noStrands; stNo++ )
-                    {
-                        //============================ Initialise variables
-                        MolStructure *sStruct;
-                        MolSheet sheet;
-                        mmdb::Strand *mmdb2Strand     = mmdb2Sheet->strand[stNo];
-                        
-                        //============================ Copy relevant information to molmodel structures
-                        sheet.num                     = mmdb2Strand->strandNo;
-                        mol_DbRecordStrGet            ( mmdb2Strand->sheetID,     1, 2, sheet.id );
-                        sheet.num_strands             = noStrands;
-                        mol_DbRecordStrGet            ( mmdb2Strand->initResName, 1, 3, sheet.init_res_name ); 
-                        sheet.init_chain_id           = mmdb2Strand->initChainID[0];
-                        sheet.init_seq_num            = mmdb2Strand->initSeqNum;
-                        sheet.init_icode              = mmdb2Strand->initICode[0];
-                        mol_DbRecordStrGet            ( mmdb2Strand->endResName,  1, 3, sheet.term_res_name );
-                        sheet.term_chain_id           = mmdb2Strand->endChainID[0];
-                        sheet.term_seq_num            = mmdb2Strand->endSeqNum;
-                        sheet.end_icode               = mmdb2Strand->endICode[0];
-                        sheet.sense                   = mmdb2Strand->sense;
-                        
-                        //============================ Save the read sheet to the molmodel model
-                        mol_MolModelCurrStrucGet      ( model, &sStruct ); // Copies model->curr_struc to sStructt
-                        
-                        MolStructureSecSheet *secStruct;
-                        MolSheet *list;
-                        secStruct                     = &sStruct->secondary.sheet;
-                        
-                        int num                       = secStruct->num;
-                        int size                      = secStruct->size;
-                        list                          = secStruct->list;
-                        if ( num == (size - 1) )
-                        {
-                          size                       += 1000;
-                          mem_Realloc                 ( list, size, sStruct->model, MolSheet* );
-                          secStruct->size             = size;
-                          secStruct->list             = list;
-                        }
 
-                        memcpy                        ( list+num, &sheet, sizeof(MolSheet) );
-                        num                          += 1;
-                        secStruct->num                = num;
-                    }
-                    
-                }
-                
-                //==================================== Find all chains for first model (the 1 in the first argument to the GetCHainTable() function)
-                mfile->GetChainTable                  ( 1, mmdb2Chain, noChains );
+            //======================================== Generate structure from block
+            gemmi::Structure gemmiStruct              = gemmi::impl::make_structure_from_block ( gemmiDoc.blocks.at(0) );
+            
+            //======================================== For each model
+            for ( unsigned int moIt = 0; moIt < static_cast<unsigned int> ( gemmiStruct.models.size() ); moIt++ )
+            {
+                //==================================== Initialise the molmodel model
+                std::stringstream molName;
+                molName << "mol" << moIt;
+                mol_MolModelCreate                    ( molName.str().c_str(), &model );
                 
                 //==================================== For each chain
-                for ( int nCh = 0; nCh < noChains; nCh++ )
+                for ( unsigned int chIt = 0; chIt < static_cast<unsigned int> ( gemmiStruct.models.at(moIt).chains.size() ); chIt++ )
                 {
-                    //================================ Check that the chain is reaable
-                    if ( mmdb2Chain[nCh] )
+                    //================================ Get the chain ID
+                    std::string chainId               =  std::string ( gemmiStruct.models.at(moIt).chains.at(chIt).name );
+                 
+                    //================================ For each residue
+                    int resNumGemmi                   = 0;
+                    for ( unsigned int reIt = 0; reIt < static_cast<unsigned int> ( gemmiStruct.models.at(moIt).chains.at(chIt).residues.size() ); reIt++ )
                     {
-                        //============================ Get all residues for this chain
-                        mfile->GetResidueTable        ( 1, nCh, mmdb2Residue, noResidues );
+                        //============================ Get residue insertion code, residueID and residue name
+                        char ICode                    = gemmiStruct.models.at(moIt).chains.at(chIt).residues.at(reIt).seqid.icode;
                         
-                        //============================ For each residue
-                        for ( int nRes = 0; nRes < noResidues; nRes++ )
+                        if ( gemmiStruct.models.at(moIt).chains.at(chIt).residues.at(reIt).seqid.num.has_value() ) { resNumGemmi = gemmiStruct.models.at(moIt).chains.at(chIt).residues.at(reIt).seqid.num.value; }
+                        else                                                                                       { resNumGemmi++; }
+                        
+                        PdbResidueId residueId        ( resNumGemmi, ICode );
+                        std::string residueName       = gemmiStruct.models.at(moIt).chains.at(chIt).residues.at(reIt).name;
+                        
+                        //============================ For each atom
+                        for ( unsigned int atIt = 0; atIt < static_cast<unsigned int> ( gemmiStruct.models.at(moIt).chains.at(chIt).residues.at(reIt).atoms.size() ); atIt++ )
                         {
-                            //======================== Check that the residue is readable
-                            if ( mmdb2Residue[nRes] )
-                            {
-                                //==================== Get all atoms
-                                mfile->GetAtomTable   ( 1, nCh, nRes, mmdb2Atom, noAtoms );
-                                
-                                //==================== For each atom
-                                for ( int aNo = 0; aNo < noAtoms; aNo++ )
-                                {
-                                    //================ Check that the atom is readable
-                                    if ( mmdb2Atom[aNo] )
-                                    {
-                                        //============ Check for termination 'residue'
-                                        if ( mmdb2Atom[aNo]->Ter )
-                                        {
-                                            //======== Initialise variables
-                                            MolStructure *terStruc;
-                                            MolChainTerm term;
-                                            
-                                            term.id   = mmdb2Atom[aNo]->serNum;
-                                            mol_DbRecordStrGet ( mmdb2Residue[nRes]->name, 1, 3, term.res_name );
-                                            term.chain_id = mmdb2Chain[nCh]->GetChainID()[0];
-                                            term.res_seq = mmdb2Residue[nRes]->seqNum;
-                                            std::string ICodeHlp = std::string ( mmdb2Residue[nRes]->GetInsCode() );
-                                            char ICode;
-                                            if ( ICodeHlp == "" ) { ICode = ' '; } else { ICode = mmdb2Residue[nRes]->GetInsCode()[0]; }
-                                            term.insertion_code = ICode;
-                                            
-                                            //============================ Save the read TER to the molmodel model
-                                            mol_MolModelCurrStrucGet ( model, &terStruc );
-                                            
-                                            MolChainTerm *tp;
-                                            mem_Alloc ( tp, 1, model, MolChainTerm* );
-                                            tp->id    = term.id;
-                                            tp->chain_id = term.chain_id;
-                                            tp->res_seq = term.res_seq;
-                                            tp->insertion_code = term.insertion_code;
-                                            strcpy    ( tp->res_name, term.res_name );
-                                            tp->next = terStruc->terms;
-                                            terStruc->terms = tp;
-                                            
-                                            continue;
-                                        }
-                                        
-                                        //============ Process atom
-                                        MolAtom atom;
-                                        MolStructure *struc;
-                                        atom.orig_id  = mmdb2Atom[aNo]->serNum;
-                                        atom.name     = mol_StrCopy( mmdb2Atom[aNo]->name, model ); // This assigns the allocated memory for the string to the model, while copying the string.
-                                        mol_ResTypeConv ( mmdb2Residue[nRes]->name, &atom.res_type );
-                                        atom.res_prop = mol_res_props[atom.res_type];
-                                        
-                                        if ( !( std::string ( mmdb2Atom[aNo]->altLoc ) == std::string ( "" ) ) &&
-                                             !( std::string ( mmdb2Atom[aNo]->altLoc ) == std::string ( "A" ) ) )
-                                            continue; // This is in keeping with the mol_DbPdbAtomProcLongChainId() function; it allows only the first alt-loc to be added.
-                                        
-                                        atom.res_seq  = mmdb2Residue[nRes]->seqNum;
-                                        std::string ICodeHlp = std::string ( mmdb2Residue[nRes]->GetInsCode() );
-                                        char ICode;
-                                        if ( ICodeHlp == "" ) { ICode = ' '; } else { ICode = mmdb2Residue[nRes]->GetInsCode()[0]; }
-                                        atom.insertion_code = ICode;
-                                        atom.pos[0]   = mmdb2Atom[aNo]->x;
-                                        atom.pos[1]   = mmdb2Atom[aNo]->y;
-                                        atom.pos[2]   = mmdb2Atom[aNo]->z;
-                                        atom.temp     = mmdb2Atom[aNo]->tempFactor;
-                                        
-                                        if (atom.name[0] != ' ') { mol_AtomTypeConv ( &atom.name[0], &atom.type ); }
-                                        else                     { mol_AtomTypeConv ( &atom.name[1], &atom.type ); }
-                                        
-                                        if ( mmdb2Atom[aNo]->Het ) { atom.het = MOL_TRUE; }
-                                        else                       { atom.het = MOL_FALSE; }
-                                        atom.chain_id = mmdb2Chain[nCh]->GetChainID()[0];
-                                        atom.long_chain_id = mol_StrCopy( " ", model ); // We do not have LongChainID, so empty
-                                        
-                                        mol_MolModelCurrStrucGet ( model, &struc );                 // Copies model->curr_struc to struc
-                                        mol_StructureAtomAdd ( struc, mmdb2Atom[aNo]->Het, &atom ); // Saves the atom to the model (through struc)
-                                    }
-                                    else
-                                    {
-                                        std::cerr << "MMDB2 failed to read the atom " << aNo << " in residue " << nRes << " in chain " << nCh << " in file " << filename << ". The file is most likely corrupted. Terminating now..." << std::endl;
-                                        exit                          ( -1 );
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                std::cerr << "MMDB2 failed to read the residue " << nRes << " in chain " << nCh << " in file " << filename << ". The file is most likely corrupted. Terminating now..." << std::endl;
-                                exit                          ( -1 );
-                            }
+                            //======================== Initialise atom related variables
+                            MolAtom atom;
+                            MolStructure *struc;
+                            
+                            //======================== Get atom info
+                            char altLoc               = gemmiStruct.models.at(moIt).chains.at(chIt).residues.at(reIt).atoms.at(atIt).altloc;
+                            
+                            //======================== Fill in atom information
+                            atom.orig_id              = gemmiStruct.models.at(moIt).chains.at(chIt).residues.at(reIt).atoms.at(atIt).serial;
+                            atom.name                 = mol_StrCopy( gemmiStruct.models.at(moIt).chains.at(chIt).residues.at(reIt).atoms.at(atIt).name.c_str(), model );
+                            mol_ResTypeConv           ( const_cast<char*> ( residueName.c_str() ), &atom.res_type );
+                            atom.res_prop             = mol_res_props[atom.res_type];
+                            
+                            if ( !( altLoc == '\0' ) && !( altLoc == 'A' ) )
+                                continue;                                                    // This is in keeping with the mol_DbPdbAtomProcLongChainId() function; it allows only the first alt-loc to be added.
+                            
+                            atom.res_seq              = resNumGemmi;
+                            atom.insertion_code       = ICode;
+                            atom.pos[0]               = gemmiStruct.models.at(moIt).chains.at(chIt).residues.at(reIt).atoms.at(atIt).pos.x;
+                            atom.pos[1]               = gemmiStruct.models.at(moIt).chains.at(chIt).residues.at(reIt).atoms.at(atIt).pos.y;
+                            atom.pos[2]               = gemmiStruct.models.at(moIt).chains.at(chIt).residues.at(reIt).atoms.at(atIt).pos.z;
+                            atom.temp                 = gemmiStruct.models.at(moIt).chains.at(chIt).residues.at(reIt).atoms.at(atIt).b_iso;
+                            
+                            atom.het                  = MOL_FALSE;                       // We do not actually know, but let's go with false here ...
+                            
+                            if (atom.name[0] != ' ')  { mol_AtomTypeConv ( &atom.name[0], &atom.type ); }
+                            else                      { mol_AtomTypeConv ( &atom.name[1], &atom.type ); }
+                            
+                            atom.chain_id             = chainId[0];
+                            atom.long_chain_id        = mol_StrCopy( " ", model );       // We do not have LongChainID, so empty
+                            
+                            mol_MolModelCurrStrucGet  ( model, &struc );                 // Copies model->curr_struc to struc
+                            mol_StructureAtomAdd      ( struc, false, &atom );           // Saves the atom to the model (through struc)
                         }
                     }
-                    else
-                    {
-                        std::cerr << "MMDB2 failed to read the chain " << nCh << " in file " << filename << ". The file is most likely corrupted. Terminating now..." << std::endl;
-                        exit                          ( -1 );
-                    }
                 }
+                
+                //==================================== Build biomolecule from the filled in structs
+                MolStructure *struc;
+                mol_MolModelCurrStrucGet              ( model, &struc ); // Fill in the struc structure
+                mol_StructureChainsBuild              ( struc, 1 );      // Build protein chains
+                mol_StructureChainsBuild              ( struc, 2 );      // Build solvent chains
             }
-            else
-            {
-                std::cerr << "MMDB2 failed to read the first model in file " << filename << ". The file is most likely corrupted. Terminating now..." << std::endl;
-                exit                                  ( -1 );
-            }
-            
-            //======================================== Build biomolecule from the filled in structs
-            MolStructure *struc;
-            mol_MolModelCurrStrucGet                  ( model, &struc ); // Fill in the struc structure
-            mol_StructureChainsBuild                  ( struc, 1 );      // Build protein chains
-            mol_StructureChainsBuild                  ( struc, 2 );      // Build solvent chains
-            
-            //======================================== Clean up
-            delete mfile;
 #else
-            std::cerr << "ERROR: The suplied file has the mmCIF format, but Molmodel was not compiled with the Gemmi library, which is required for the mmCIF support. Please re-run the Molmodel cmake command with the -DUSE_GEMMI=TRUE -DGEMMI_PATH=/path/to/gemmi/include options (and then alse re-run the make install command). Terminating..." << std::endl;
+            std::cerr << "ERROR: The suplied file has the mmCIF format, but Molmodel was not compiled with the Gemmi library, which is required for the mmCIF support. Please re-run the Molmodel cmake command with the -DUSE_GEMMI=TRUE -DGEMMI_PATH=/path/to/gemmi/include option (and then alse re-run the make install command). Terminating..." << std::endl;
             exit                                      ( -1 );
 #endif
         }

--- a/src/Pdb.cpp
+++ b/src/Pdb.cpp
@@ -4,6 +4,8 @@
 #include "molmodel/internal/Pdb.h"
 #include "molmodel/internal/Compound.h"
 #include <stdexcept>
+#include <algorithm>
+#include <cctype>
 
 #ifdef GEMMI_USAGE
     //================================================ Include Gemmi headers
@@ -896,12 +898,16 @@ PdbStructure::PdbStructure(
             {
                 //==================================== Get atom name
                 String atomName                       = std::string ( gemmiStruct.models.at(0).chains.at(chIt).residues.at(reIt).atoms.at(atIt).name );
+                if ( atomName.length() == 3 ) { atomName.insert ( 0, " " ); }
+                if ( atomName.length() == 2 ) { atomName = " " + atomName + " "; }
+                if ( atomName.length() == 1 ) { atomName = " " + atomName + "  "; }
                 
                 //==================================== If this atom does not yet exist in molmodel, add it
                 if ( !models.back().chains[models.back().chainIndicesById[chainId]].residues[models.back().chains[models.back().chainIndicesById[chainId]].residueIndicesById[residueId]].hasAtom( atomName ) )
                 {
                     //================================ Molmodel makes assumption that second element symbol (if it exists) must be lowercase, if the first one is uppercase. Keeping in line with this assumption
                     String elementSymbol              = std::string ( gemmiStruct.models.at(0).chains.at(chIt).residues.at(reIt).atoms.at(atIt).element.name() );
+                    while ( elementSymbol.length() < 2 ) { elementSymbol.insert ( 0, " " ); }
                     if ( ( elementSymbol.length() > 1 ) && ( toupper (  elementSymbol[0] ) ==  elementSymbol[0] ) ) { elementSymbol[1] = tolower ( elementSymbol[1] ); }
                     
                     //================================ Four character atom names starting with "H" are probably hydrogen, even if they start with "HO", which should properly be Holmium. - taken from molmodel


### PR DESCRIPTION
This pull request removes the requirements for the CMAPLIB and the MMDB2 libraries and instead introduces the Gemmi library to provide the required functionality. Therefore, it should not affect any molmodel functionality except for the mmCIF reading. Also, it should now be possible to supply gunzipped files (.cif.gz) as well as uncompressed files (.cif).

NOTE: The CMakeLists.txt file has been re-formatted to use unix end-of-lines instead of the MS DOS ones, as I was unable to edit the file otherwise.
